### PR TITLE
Report cypress tests to currents.dev dashboard

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,4 @@
 {
 	"baseUrl": "https://chat-dev.parley.nu:8181",
-	"projectId": "wwda8d"
+	"projectId": "lHz0tz"
 }

--- a/cypress/integration/ui_spec.js
+++ b/cypress/integration/ui_spec.js
@@ -328,7 +328,7 @@ describe("UI", () => {
 					});
 					it("should only show welcomeMessage after GET /messages call", () => {
 						// Cancel outgoing GET /messages (this works better than a long delay)
-						// This wat we can see what happens while the request is busy
+						// This way we can see what happens while the request is busy
 						cy.intercept("GET", "*/**/messages", (req) => {
 							// never call req.continue();
 						});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
 			"version": "2.0.0-alpha.3",
 			"license": "MIT",
 			"dependencies": {
+				"@currents/cli": "^1.0.8",
 				"@fortawesome/fontawesome-free": "^5.15.3",
 				"@fortawesome/fontawesome-svg-core": "^1.2.35",
 				"@fortawesome/free-regular-svg-icons": "^5.15.3",
@@ -39,7 +40,7 @@
 				"@parcel/transformer-svg-react": "^2.0.0-beta.3.1",
 				"@parcel/transformer-svgo": "^2.0.0-beta.3.1",
 				"babel-plugin-istanbul": "^6.0.0",
-				"cypress": "^8.0.0",
+				"cypress": "^8.7.0",
 				"eslint": "^7.31.0",
 				"eslint-plugin-compat": "^3.9.0",
 				"eslint-plugin-cypress": "^2.11.3",
@@ -1402,6 +1403,17 @@
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/@currents/cli": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@currents/cli/-/cli-1.0.8.tgz",
+			"integrity": "sha512-qkSyjHW1ek4J/0v5Y/1dkdmOVH/6r2k8666ssUy5m7t3vTIHVzVMTqNVS0egOeOKJ18iYr0MQU1SD4fIT6NueA==",
+			"dependencies": {
+				"cy2": "1.2.1"
+			},
+			"bin": {
+				"currents": "bin/currents.js"
+			}
+		},
 		"node_modules/@cypress/browserify-preprocessor": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@cypress/browserify-preprocessor/-/browserify-preprocessor-3.0.1.tgz",
@@ -1691,9 +1703,9 @@
 			}
 		},
 		"node_modules/@cypress/request": {
-			"version": "2.88.5",
-			"resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.5.tgz",
-			"integrity": "sha512-TzEC1XMi1hJkywWpRfD2clreTa/Z+lOrXDCxxBTBPEcY5azdPi56A6Xw+O4tWJnaJH3iIE7G5aDXZC6JgRZLcA==",
+			"version": "2.88.10",
+			"resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.10.tgz",
+			"integrity": "sha512-Zp7F+R93N0yZyG34GutyTNr+okam7s/Fzc1+i3kcqOP8vk6OuajuE9qZJ6Rs+10/1JFtXFYMdyarnU1rZuJesg==",
 			"dev": true,
 			"dependencies": {
 				"aws-sign2": "~0.7.0",
@@ -1703,43 +1715,85 @@
 				"extend": "~3.0.2",
 				"forever-agent": "~0.6.1",
 				"form-data": "~2.3.2",
-				"har-validator": "~5.1.3",
-				"http-signature": "~1.2.0",
+				"http-signature": "~1.3.6",
 				"is-typedarray": "~1.0.0",
 				"isstream": "~0.1.2",
 				"json-stringify-safe": "~5.0.1",
 				"mime-types": "~2.1.19",
-				"oauth-sign": "~0.9.0",
 				"performance-now": "^2.1.0",
 				"qs": "~6.5.2",
 				"safe-buffer": "^5.1.2",
 				"tough-cookie": "~2.5.0",
 				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.3.2"
+				"uuid": "^8.3.2"
 			},
 			"engines": {
 				"node": ">= 6"
 			}
 		},
+		"node_modules/@cypress/request/node_modules/http-signature": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
+			"integrity": "sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
+			"dev": true,
+			"dependencies": {
+				"assert-plus": "^1.0.0",
+				"jsprim": "^2.0.2",
+				"sshpk": "^1.14.1"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/@cypress/request/node_modules/json-schema": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+			"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+			"dev": true
+		},
+		"node_modules/@cypress/request/node_modules/jsprim": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
+			"integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
+			"dev": true,
+			"engines": [
+				"node >=0.6.0"
+			],
+			"dependencies": {
+				"assert-plus": "1.0.0",
+				"extsprintf": "1.3.0",
+				"json-schema": "0.4.0",
+				"verror": "1.10.0"
+			}
+		},
 		"node_modules/@cypress/request/node_modules/mime-db": {
-			"version": "1.48.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
-			"integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==",
+			"version": "1.51.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
+			"integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
 			"dev": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
 		},
 		"node_modules/@cypress/request/node_modules/mime-types": {
-			"version": "2.1.31",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
-			"integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
+			"version": "2.1.34",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
+			"integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
 			"dev": true,
 			"dependencies": {
-				"mime-db": "1.48.0"
+				"mime-db": "1.51.0"
 			},
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/@cypress/request/node_modules/uuid": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+			"dev": true,
+			"bin": {
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/@cypress/xvfb": {
@@ -3840,9 +3894,9 @@
 			"dev": true
 		},
 		"node_modules/@types/sinonjs__fake-timers": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
-			"integrity": "sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==",
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.4.tgz",
+			"integrity": "sha512-IFQTJARgMUBF+xVd2b+hIgXWrZEjND3vJtRCvIelcFB5SIXfjV4bOHbHJ0eXKh+0COrBRc8MqteKAz/j88rE0A==",
 			"dev": true
 		},
 		"node_modules/@types/sizzle": {
@@ -3857,9 +3911,9 @@
 			"integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
 		},
 		"node_modules/@types/yauzl": {
-			"version": "2.9.1",
-			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
-			"integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
+			"integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
 			"dev": true,
 			"optional": true,
 			"dependencies": {
@@ -4288,9 +4342,9 @@
 			}
 		},
 		"node_modules/async": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-			"integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
+			"integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g==",
 			"dev": true
 		},
 		"node_modules/async-each": {
@@ -4459,7 +4513,6 @@
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
 			"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
 			"dev": true,
-			"hasInstallScript": true,
 			"optional": true,
 			"os": [
 				"darwin"
@@ -5449,9 +5502,9 @@
 			}
 		},
 		"node_modules/ci-info": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
-			"integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
+			"integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
 			"dev": true
 		},
 		"node_modules/cipher-base": {
@@ -5823,9 +5876,9 @@
 			}
 		},
 		"node_modules/common-tags": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
-			"integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+			"integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
 			"dev": true,
 			"engines": {
 				"node": ">=4.0.0"
@@ -6363,13 +6416,44 @@
 				"cssom": "0.3.x"
 			}
 		},
+		"node_modules/cy2": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/cy2/-/cy2-1.2.1.tgz",
+			"integrity": "sha512-wT99aBDkMcsmbAYK6mwfDTbH43tN/hyaJ2NrLYfjid9bDTx3rn7UaPKWOIRZtT7L2v32zbMp/GTRtHO3HWb23Q==",
+			"dependencies": {
+				"js-yaml": "^4.0.0",
+				"npm-which": "^3.0.1"
+			},
+			"bin": {
+				"cy2": "bin/cy2"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/cy2/node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+		},
+		"node_modules/cy2/node_modules/js-yaml": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
 		"node_modules/cypress": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/cypress/-/cypress-8.0.0.tgz",
-			"integrity": "sha512-Hhbc7FtbeCSg5Ui2zxXQLynk7IYGIygG8NqTauS4EtCWyp2k6s4g8P4KUZXwRbhuryN/+/dCd1kPtFbhBx8MuQ==",
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/cypress/-/cypress-8.7.0.tgz",
+			"integrity": "sha512-b1bMC3VQydC6sXzBMFnSqcvwc9dTZMgcaOzT0vpSD+Gq1yFc+72JDWi55sfUK5eIeNLAtWOGy1NNb6UlhMvB+Q==",
 			"dev": true,
 			"dependencies": {
-				"@cypress/request": "^2.88.5",
+				"@cypress/request": "^2.88.6",
 				"@cypress/xvfb": "^1.2.4",
 				"@types/node": "^14.14.31",
 				"@types/sinonjs__fake-timers": "^6.0.2",
@@ -6403,6 +6487,7 @@
 				"minimist": "^1.2.5",
 				"ospath": "^1.2.2",
 				"pretty-bytes": "^5.6.0",
+				"proxy-from-env": "1.0.0",
 				"ramda": "~0.27.1",
 				"request-progress": "^3.0.0",
 				"supports-color": "^8.1.1",
@@ -6419,9 +6504,9 @@
 			}
 		},
 		"node_modules/cypress/node_modules/@types/node": {
-			"version": "14.17.3",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.3.tgz",
-			"integrity": "sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw==",
+			"version": "14.18.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.0.tgz",
+			"integrity": "sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ==",
 			"dev": true
 		},
 		"node_modules/cypress/node_modules/ansi-styles": {
@@ -6443,9 +6528,9 @@
 			"dev": true
 		},
 		"node_modules/cypress/node_modules/chalk": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-			"integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
@@ -6495,9 +6580,9 @@
 			}
 		},
 		"node_modules/cypress/node_modules/debug": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 			"dev": true,
 			"dependencies": {
 				"ms": "2.1.2"
@@ -7786,9 +7871,9 @@
 			}
 		},
 		"node_modules/eventemitter2": {
-			"version": "6.4.4",
-			"resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.4.tgz",
-			"integrity": "sha512-HLU3NDY6wARrLCEwyGKRBvuWYyvW6mHYv72SJJAH3iJN3a6eVUvkjFkcxah1bcTgGVBBrFdIopBJPhCQFMLyXw==",
+			"version": "6.4.5",
+			"resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.5.tgz",
+			"integrity": "sha512-bXE7Dyc1i6oQElDG0jMRZJrRAn9QR2xyyFGmBdZleNmyQX0FqGYmhZIrIrpPfm/w//LTo4tVQGOGQcGCb5q9uw==",
 			"dev": true
 		},
 		"node_modules/eventemitter3": {
@@ -8043,9 +8128,9 @@
 			}
 		},
 		"node_modules/extract-zip/node_modules/debug": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-			"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 			"dev": true,
 			"dependencies": {
 				"ms": "2.1.2"
@@ -9712,12 +9797,12 @@
 			}
 		},
 		"node_modules/is-ci": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.0.tgz",
-			"integrity": "sha512-kDXyttuLeslKAHYL/K28F2YkM3x5jvFPEw3yXbRptXydjD9rpLEz+C5K5iutY9ZiUu6AP41JdvRQwF4Iqs4ZCQ==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+			"integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
 			"dev": true,
 			"dependencies": {
-				"ci-info": "^3.1.1"
+				"ci-info": "^3.2.0"
 			},
 			"bin": {
 				"is-ci": "bin.js"
@@ -10139,8 +10224,7 @@
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-			"dev": true
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"node_modules/isobject": {
 			"version": "3.0.1",
@@ -10699,22 +10783,29 @@
 			"dev": true
 		},
 		"node_modules/listr2": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/listr2/-/listr2-3.10.0.tgz",
-			"integrity": "sha512-eP40ZHihu70sSmqFNbNy2NL1YwImmlMmPh9WO5sLmPDleurMHt3n+SwEWNu2kzKScexZnkyFtc1VI0z/TGlmpw==",
+			"version": "3.13.5",
+			"resolved": "https://registry.npmjs.org/listr2/-/listr2-3.13.5.tgz",
+			"integrity": "sha512-3n8heFQDSk+NcwBn3CgxEibZGaRzx+pC64n3YjpMD1qguV4nWus3Al+Oo3KooqFKTQEJ1v7MmnbnyyNspgx3NA==",
 			"dev": true,
 			"dependencies": {
 				"cli-truncate": "^2.1.0",
-				"colorette": "^1.2.2",
+				"colorette": "^2.0.16",
 				"log-update": "^4.0.0",
 				"p-map": "^4.0.0",
-				"rxjs": "^6.6.7",
+				"rfdc": "^1.3.0",
+				"rxjs": "^7.4.0",
 				"through": "^2.3.8",
 				"wrap-ansi": "^7.0.0"
 			},
 			"engines": {
 				"node": ">=10.0.0"
 			}
+		},
+		"node_modules/listr2/node_modules/colorette": {
+			"version": "2.0.16",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+			"integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+			"dev": true
 		},
 		"node_modules/lmdb-store": {
 			"version": "1.6.3",
@@ -11795,6 +11886,31 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/npm-path": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.4.tgz",
+			"integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
+			"dependencies": {
+				"which": "^1.2.10"
+			},
+			"bin": {
+				"npm-path": "bin/npm-path"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/npm-path/node_modules/which": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"which": "bin/which"
+			}
+		},
 		"node_modules/npm-run-path": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -11805,6 +11921,38 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/npm-which": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
+			"integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
+			"dependencies": {
+				"commander": "^2.9.0",
+				"npm-path": "^2.0.2",
+				"which": "^1.2.10"
+			},
+			"bin": {
+				"npm-which": "bin/npm-which.js"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		},
+		"node_modules/npm-which/node_modules/commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+		},
+		"node_modules/npm-which/node_modules/which": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"which": "bin/which"
 			}
 		},
 		"node_modules/nth-check": {
@@ -13928,6 +14076,12 @@
 				"xtend": "^4.0.0"
 			}
 		},
+		"node_modules/proxy-from-env": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+			"integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+			"dev": true
+		},
 		"node_modules/psl": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -14644,6 +14798,12 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/rfdc": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+			"integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+			"dev": true
+		},
 		"node_modules/rgb-regex": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
@@ -14688,15 +14848,12 @@
 			}
 		},
 		"node_modules/rxjs": {
-			"version": "6.6.7",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-			"integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
+			"integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
 			"dev": true,
 			"dependencies": {
-				"tslib": "^1.9.0"
-			},
-			"engines": {
-				"npm": ">=2.0.0"
+				"tslib": "~2.1.0"
 			}
 		},
 		"node_modules/safe-buffer": {
@@ -16488,9 +16645,9 @@
 			"integrity": "sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w=="
 		},
 		"node_modules/tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+			"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
 			"dev": true
 		},
 		"node_modules/tty-browserify": {
@@ -17182,7 +17339,6 @@
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
 			"integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
 			"dev": true,
-			"hasInstallScript": true,
 			"optional": true,
 			"os": [
 				"darwin"
@@ -18789,6 +18945,14 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
+		"@currents/cli": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@currents/cli/-/cli-1.0.8.tgz",
+			"integrity": "sha512-qkSyjHW1ek4J/0v5Y/1dkdmOVH/6r2k8666ssUy5m7t3vTIHVzVMTqNVS0egOeOKJ18iYr0MQU1SD4fIT6NueA==",
+			"requires": {
+				"cy2": "1.2.1"
+			}
+		},
 		"@cypress/browserify-preprocessor": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@cypress/browserify-preprocessor/-/browserify-preprocessor-3.0.1.tgz",
@@ -19057,9 +19221,9 @@
 			}
 		},
 		"@cypress/request": {
-			"version": "2.88.5",
-			"resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.5.tgz",
-			"integrity": "sha512-TzEC1XMi1hJkywWpRfD2clreTa/Z+lOrXDCxxBTBPEcY5azdPi56A6Xw+O4tWJnaJH3iIE7G5aDXZC6JgRZLcA==",
+			"version": "2.88.10",
+			"resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.10.tgz",
+			"integrity": "sha512-Zp7F+R93N0yZyG34GutyTNr+okam7s/Fzc1+i3kcqOP8vk6OuajuE9qZJ6Rs+10/1JFtXFYMdyarnU1rZuJesg==",
 			"dev": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
@@ -19069,35 +19233,68 @@
 				"extend": "~3.0.2",
 				"forever-agent": "~0.6.1",
 				"form-data": "~2.3.2",
-				"har-validator": "~5.1.3",
-				"http-signature": "~1.2.0",
+				"http-signature": "~1.3.6",
 				"is-typedarray": "~1.0.0",
 				"isstream": "~0.1.2",
 				"json-stringify-safe": "~5.0.1",
 				"mime-types": "~2.1.19",
-				"oauth-sign": "~0.9.0",
 				"performance-now": "^2.1.0",
 				"qs": "~6.5.2",
 				"safe-buffer": "^5.1.2",
 				"tough-cookie": "~2.5.0",
 				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.3.2"
+				"uuid": "^8.3.2"
 			},
 			"dependencies": {
+				"http-signature": {
+					"version": "1.3.6",
+					"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.3.6.tgz",
+					"integrity": "sha512-3adrsD6zqo4GsTqtO7FyrejHNv+NgiIfAfv68+jVlFmSr9OGy7zrxONceFRLKvnnZA5jbxQBX1u9PpB6Wi32Gw==",
+					"dev": true,
+					"requires": {
+						"assert-plus": "^1.0.0",
+						"jsprim": "^2.0.2",
+						"sshpk": "^1.14.1"
+					}
+				},
+				"json-schema": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+					"integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+					"dev": true
+				},
+				"jsprim": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
+					"integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
+					"dev": true,
+					"requires": {
+						"assert-plus": "1.0.0",
+						"extsprintf": "1.3.0",
+						"json-schema": "0.4.0",
+						"verror": "1.10.0"
+					}
+				},
 				"mime-db": {
-					"version": "1.48.0",
-					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
-					"integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==",
+					"version": "1.51.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
+					"integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
 					"dev": true
 				},
 				"mime-types": {
-					"version": "2.1.31",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
-					"integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
+					"version": "2.1.34",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
+					"integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
 					"dev": true,
 					"requires": {
-						"mime-db": "1.48.0"
+						"mime-db": "1.51.0"
 					}
+				},
+				"uuid": {
+					"version": "8.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+					"dev": true
 				}
 			}
 		},
@@ -20819,9 +21016,9 @@
 			"dev": true
 		},
 		"@types/sinonjs__fake-timers": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
-			"integrity": "sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==",
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.4.tgz",
+			"integrity": "sha512-IFQTJARgMUBF+xVd2b+hIgXWrZEjND3vJtRCvIelcFB5SIXfjV4bOHbHJ0eXKh+0COrBRc8MqteKAz/j88rE0A==",
 			"dev": true
 		},
 		"@types/sizzle": {
@@ -20836,9 +21033,9 @@
 			"integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
 		},
 		"@types/yauzl": {
-			"version": "2.9.1",
-			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
-			"integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
+			"integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
 			"dev": true,
 			"optional": true,
 			"requires": {
@@ -21190,9 +21387,9 @@
 			"dev": true
 		},
 		"async": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-			"integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
+			"integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g==",
 			"dev": true
 		},
 		"async-each": {
@@ -22202,9 +22399,9 @@
 			"dev": true
 		},
 		"ci-info": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
-			"integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
+			"integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
 			"dev": true
 		},
 		"cipher-base": {
@@ -22512,9 +22709,9 @@
 			"dev": true
 		},
 		"common-tags": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
-			"integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+			"integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
 			"dev": true
 		},
 		"commondir": {
@@ -22982,13 +23179,37 @@
 				"cssom": "0.3.x"
 			}
 		},
+		"cy2": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/cy2/-/cy2-1.2.1.tgz",
+			"integrity": "sha512-wT99aBDkMcsmbAYK6mwfDTbH43tN/hyaJ2NrLYfjid9bDTx3rn7UaPKWOIRZtT7L2v32zbMp/GTRtHO3HWb23Q==",
+			"requires": {
+				"js-yaml": "^4.0.0",
+				"npm-which": "^3.0.1"
+			},
+			"dependencies": {
+				"argparse": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+				},
+				"js-yaml": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+					"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+					"requires": {
+						"argparse": "^2.0.1"
+					}
+				}
+			}
+		},
 		"cypress": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/cypress/-/cypress-8.0.0.tgz",
-			"integrity": "sha512-Hhbc7FtbeCSg5Ui2zxXQLynk7IYGIygG8NqTauS4EtCWyp2k6s4g8P4KUZXwRbhuryN/+/dCd1kPtFbhBx8MuQ==",
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/cypress/-/cypress-8.7.0.tgz",
+			"integrity": "sha512-b1bMC3VQydC6sXzBMFnSqcvwc9dTZMgcaOzT0vpSD+Gq1yFc+72JDWi55sfUK5eIeNLAtWOGy1NNb6UlhMvB+Q==",
 			"dev": true,
 			"requires": {
-				"@cypress/request": "^2.88.5",
+				"@cypress/request": "^2.88.6",
 				"@cypress/xvfb": "^1.2.4",
 				"@types/node": "^14.14.31",
 				"@types/sinonjs__fake-timers": "^6.0.2",
@@ -23022,6 +23243,7 @@
 				"minimist": "^1.2.5",
 				"ospath": "^1.2.2",
 				"pretty-bytes": "^5.6.0",
+				"proxy-from-env": "1.0.0",
 				"ramda": "~0.27.1",
 				"request-progress": "^3.0.0",
 				"supports-color": "^8.1.1",
@@ -23032,9 +23254,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "14.17.3",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.3.tgz",
-					"integrity": "sha512-e6ZowgGJmTuXa3GyaPbTGxX17tnThl2aSSizrFthQ7m9uLGZBXiGhgE55cjRZTF5kjZvYn9EOPOMljdjwbflxw==",
+					"version": "14.18.0",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.0.tgz",
+					"integrity": "sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ==",
 					"dev": true
 				},
 				"ansi-styles": {
@@ -23053,9 +23275,9 @@
 					"dev": true
 				},
 				"chalk": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-					"integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
@@ -23095,9 +23317,9 @@
 					"dev": true
 				},
 				"debug": {
-					"version": "4.3.2",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"version": "4.3.3",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
@@ -24156,9 +24378,9 @@
 			"dev": true
 		},
 		"eventemitter2": {
-			"version": "6.4.4",
-			"resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.4.tgz",
-			"integrity": "sha512-HLU3NDY6wARrLCEwyGKRBvuWYyvW6mHYv72SJJAH3iJN3a6eVUvkjFkcxah1bcTgGVBBrFdIopBJPhCQFMLyXw==",
+			"version": "6.4.5",
+			"resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.5.tgz",
+			"integrity": "sha512-bXE7Dyc1i6oQElDG0jMRZJrRAn9QR2xyyFGmBdZleNmyQX0FqGYmhZIrIrpPfm/w//LTo4tVQGOGQcGCb5q9uw==",
 			"dev": true
 		},
 		"eventemitter3": {
@@ -24365,9 +24587,9 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "4.3.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"version": "4.3.3",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+					"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
@@ -25733,12 +25955,12 @@
 			"dev": true
 		},
 		"is-ci": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.0.tgz",
-			"integrity": "sha512-kDXyttuLeslKAHYL/K28F2YkM3x5jvFPEw3yXbRptXydjD9rpLEz+C5K5iutY9ZiUu6AP41JdvRQwF4Iqs4ZCQ==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+			"integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
 			"dev": true,
 			"requires": {
-				"ci-info": "^3.1.1"
+				"ci-info": "^3.2.0"
 			}
 		},
 		"is-color-stop": {
@@ -26063,8 +26285,7 @@
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-			"dev": true
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
 		},
 		"isobject": {
 			"version": "3.0.1",
@@ -26521,18 +26742,27 @@
 			"dev": true
 		},
 		"listr2": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/listr2/-/listr2-3.10.0.tgz",
-			"integrity": "sha512-eP40ZHihu70sSmqFNbNy2NL1YwImmlMmPh9WO5sLmPDleurMHt3n+SwEWNu2kzKScexZnkyFtc1VI0z/TGlmpw==",
+			"version": "3.13.5",
+			"resolved": "https://registry.npmjs.org/listr2/-/listr2-3.13.5.tgz",
+			"integrity": "sha512-3n8heFQDSk+NcwBn3CgxEibZGaRzx+pC64n3YjpMD1qguV4nWus3Al+Oo3KooqFKTQEJ1v7MmnbnyyNspgx3NA==",
 			"dev": true,
 			"requires": {
 				"cli-truncate": "^2.1.0",
-				"colorette": "^1.2.2",
+				"colorette": "^2.0.16",
 				"log-update": "^4.0.0",
 				"p-map": "^4.0.0",
-				"rxjs": "^6.6.7",
+				"rfdc": "^1.3.0",
+				"rxjs": "^7.4.0",
 				"through": "^2.3.8",
 				"wrap-ansi": "^7.0.0"
+			},
+			"dependencies": {
+				"colorette": {
+					"version": "2.0.16",
+					"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+					"integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+					"dev": true
+				}
 			}
 		},
 		"lmdb-store": {
@@ -27472,6 +27702,24 @@
 			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
 			"dev": true
 		},
+		"npm-path": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.4.tgz",
+			"integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
+			"requires": {
+				"which": "^1.2.10"
+			},
+			"dependencies": {
+				"which": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
+		},
 		"npm-run-path": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -27479,6 +27727,31 @@
 			"dev": true,
 			"requires": {
 				"path-key": "^3.0.0"
+			}
+		},
+		"npm-which": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
+			"integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
+			"requires": {
+				"commander": "^2.9.0",
+				"npm-path": "^2.0.2",
+				"which": "^1.2.10"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+				},
+				"which": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
 			}
 		},
 		"nth-check": {
@@ -29212,6 +29485,12 @@
 				"xtend": "^4.0.0"
 			}
 		},
+		"proxy-from-env": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+			"integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+			"dev": true
+		},
 		"psl": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -29821,6 +30100,12 @@
 			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
 			"dev": true
 		},
+		"rfdc": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+			"integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+			"dev": true
+		},
 		"rgb-regex": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/rgb-regex/-/rgb-regex-1.0.1.tgz",
@@ -29862,12 +30147,12 @@
 			}
 		},
 		"rxjs": {
-			"version": "6.6.7",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-			"integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
+			"integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
 			"dev": true,
 			"requires": {
-				"tslib": "^1.9.0"
+				"tslib": "~2.1.0"
 			}
 		},
 		"safe-buffer": {
@@ -31387,9 +31672,9 @@
 			"integrity": "sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w=="
 		},
 		"tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+			"integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
 			"dev": true
 		},
 		"tty-browserify": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
 		}
 	},
 	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1",
 		"start": "npx parcel serve --host chat-dev.parley.nu --https --cert ssl/ssl.cert --key ssl/ssl.key --no-autoinstall --port 8181 --target ui-for-watcher index.html",
 		"build": "npx parcel build --target ui-minimized --target ui-sourcemapped index.html",
 		"build-cdn-demo": "npx parcel build --target cdn-demo-live --target cdn-demo-local parleycdn-demo/index.html",
@@ -40,8 +39,8 @@
 		"test:coverage": "npx nyc report --reporter=lcov --reporter=text-summary && echo '\nOpen coverage/lcov-report/index.html for html view'",
 		"zip": "cd ./dist/ui && for i in */; do zip -r \"${i%/}.zip\" \"$i\"; done",
 		"release": "rm -rf ./dist/ui && npm run build && npm run build-cdn-demo && npm run zip",
-		"ci:server": "npx parcel serve --host 127.0.0.1 --no-autoinstall --port 8181 --target ui-sourcemapped index.html",
-		"ci:tests": "cypress run --record --config 'baseUrl=http://127.0.0.1:8181'"
+		"ci:server": "npx parcel serve --host 127.0.0.1 --no-autoinstall --port 8182 --target ui-sourcemapped index.html",
+		"ci:tests": "npx currents run --record --config 'baseUrl=http://127.0.0.1:8182'"
 	},
 	"repository": {
 		"type": "git",
@@ -76,6 +75,7 @@
 	},
 	"homepage": "https://github.com/parley-messaging/web-library#readme",
 	"dependencies": {
+		"@currents/cli": "^1.0.8",
 		"@fortawesome/fontawesome-free": "^5.15.3",
 		"@fortawesome/fontawesome-svg-core": "^1.2.35",
 		"@fortawesome/free-regular-svg-icons": "^5.15.3",
@@ -107,7 +107,7 @@
 		"@parcel/transformer-svg-react": "^2.0.0-beta.3.1",
 		"@parcel/transformer-svgo": "^2.0.0-beta.3.1",
 		"babel-plugin-istanbul": "^6.0.0",
-		"cypress": "^8.0.0",
+		"cypress": "^8.7.0",
 		"eslint": "^7.31.0",
 		"eslint-plugin-compat": "^3.9.0",
 		"eslint-plugin-cypress": "^2.11.3",


### PR DESCRIPTION
Use currents.dev instead of dashboard.cypress.io because it is way cheaper.