### PR TITLE
Added default index for parley messaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 		:root {
 			--parley-mobile-height: 1vh;
 			--parley-mobile-width: 1vw;
-			--parley-index-prefix: 100;
+			--parley-base-z-index: 100;
 			--parley-font: 'OpenSans', sans-serif;
 			--parley-background-color: #FFF;
 			--parley-nav-background-color: #00006B;

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
 		:root {
 			--parley-mobile-height: 1vh;
 			--parley-mobile-width: 1vw;
+			--parley-index-prefix: 100;
 			--parley-font: 'OpenSans', sans-serif;
 			--parley-background-color: #FFF;
 			--parley-nav-background-color: #00006B;

--- a/src/UI/Buttons/MobileSubmit.module.css
+++ b/src/UI/Buttons/MobileSubmit.module.css
@@ -1,6 +1,5 @@
 .mobile {
 	position: unset;
-	z-index: 2;
 	right: unset;
 	bottom: unset;
 	width: 25px;

--- a/src/UI/Chat.module.css
+++ b/src/UI/Chat.module.css
@@ -1,6 +1,6 @@
 .chat {
 	position: fixed;
-	z-index: 2002;
+	z-index: calc(var(--parley-index-prefix, 100) + 2);
 	right: 20px;
 	bottom: 90px;
 	display: grid;

--- a/src/UI/Chat.module.css
+++ b/src/UI/Chat.module.css
@@ -1,6 +1,6 @@
 .chat {
 	position: fixed;
-	z-index: calc(var(--parley-index-prefix, 100) + 2);
+	z-index: calc(var(--parley-base-z-index, 100) + 2);
 	right: 20px;
 	bottom: 90px;
 	display: grid;

--- a/src/UI/Header.module.css
+++ b/src/UI/Header.module.css
@@ -1,5 +1,5 @@
 .header {
-	z-index: calc(var(--parley-index-prefix, 100) + 3);
+	z-index: calc(var(--parley-base-z-index, 100) + 3);
 	top: 0;
 	display: grid;
 	margin: 0;

--- a/src/UI/Header.module.css
+++ b/src/UI/Header.module.css
@@ -1,5 +1,5 @@
 .header {
-	z-index: 1998;
+	z-index: calc(var(--parley-index-prefix, 100) + 3);
 	top: 0;
 	display: grid;
 	margin: 0;

--- a/src/UI/Header.module.css
+++ b/src/UI/Header.module.css
@@ -1,5 +1,4 @@
 .header {
-	z-index: calc(var(--parley-base-z-index, 100) + 3);
 	top: 0;
 	display: grid;
 	margin: 0;

--- a/src/UI/Launcher.module.css
+++ b/src/UI/Launcher.module.css
@@ -1,6 +1,6 @@
 .launcher {
 	position: fixed;
-	z-index: calc(var(--parley-index-prefix, 100) + 1);
+	z-index: calc(var(--parley-base-z-index, 100) + 1);
 	right: 20px;
 	bottom: 20px;
 	width: 50px;

--- a/src/UI/Launcher.module.css
+++ b/src/UI/Launcher.module.css
@@ -1,6 +1,6 @@
 .launcher {
 	position: fixed;
-	z-index: 2000;
+	z-index: calc(var(--parley-index-prefix, 100) + 1);
 	right: 20px;
 	bottom: 20px;
 	width: 50px;

--- a/src/UI/ReplyActions.module.css
+++ b/src/UI/ReplyActions.module.css
@@ -1,5 +1,5 @@
 .footer {
-	z-index: 1999;
+	z-index: calc(var(--parley-index-prefix, 100) + 4);
 	display: grid;
 	width: 100%;
 	box-sizing: border-box;
@@ -12,7 +12,7 @@
 }
 
 .actions {
-	z-index: 1;
+	z-index: calc(var(--parley-index-prefix, 100) + 5);
 	display: grid;
 
 	/*Only use when you have 2 buttons */

--- a/src/UI/ReplyActions.module.css
+++ b/src/UI/ReplyActions.module.css
@@ -1,5 +1,4 @@
 .footer {
-	z-index: calc(var(--parley-base-z-index, 100) + 4);
 	display: grid;
 	width: 100%;
 	box-sizing: border-box;
@@ -12,7 +11,6 @@
 }
 
 .actions {
-	z-index: calc(var(--parley-base-z-index, 100) + 5);
 	display: grid;
 
 	/*Only use when you have 2 buttons */

--- a/src/UI/ReplyActions.module.css
+++ b/src/UI/ReplyActions.module.css
@@ -1,5 +1,5 @@
 .footer {
-	z-index: calc(var(--parley-index-prefix, 100) + 4);
+	z-index: calc(var(--parley-base-z-index, 100) + 4);
 	display: grid;
 	width: 100%;
 	box-sizing: border-box;
@@ -12,7 +12,7 @@
 }
 
 .actions {
-	z-index: calc(var(--parley-index-prefix, 100) + 5);
+	z-index: calc(var(--parley-base-z-index, 100) + 5);
 	display: grid;
 
 	/*Only use when you have 2 buttons */


### PR DESCRIPTION
We had a fixed z-index in the project and client asked if we could set a default preset that could be manipulated by their CSS. CSS var name that can be changed to influence the base z-index is `--parley-base-z-index` and its default is 100+ specific order their in.

Screenshot as proof that nothing changed:
![Screenshot 2023-06-06 144554](https://github.com/parley-messaging/web-library/assets/49270238/7d4fcb34-3e26-42cd-857e-3b3169e97cee)
