### PR TITLE
Version number bump and readme change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-# Develop
+# Documentation
+Moved to https://developers.parley.nu/docs/introduction-2  
+(the pages are unlisted at the moment until the official release of version 2)
 
+# Develop
 ## Initial configuration
 To help develop this library you will need to set-up you environment. Follow the steps below to get started.
 
@@ -63,37 +66,3 @@ You can find more info on how to enable WSL on windows 10 here: https://docs.mic
 ```
 npm run cy:open
 ```
-
-## Using the `apiCustomHeaders` setting
-You can add your own headers to the API calls made by the library, by using the `window.parleySettings.apiCustomHeaders` setting.
-This setting expects an Object where each key is the header name and the value is the header value.
-Some headers are not allowed to be overridden:
-- Headers in the `src/Api/Constants/CustomHeaderBlacklist.js`
-- Headers beginning with prefix "x-parley-"
-- Headers beginning with prefix "x-iris-"
-
-⚡ This setting is reactive: It automatically merges* any changes, during runtime, with the previous values  
-_* = Because it **merges** the previous values with the new values, it is not possible te remove values. This might change in the future_
-
-## Using the `userAdditionalInformation` setting
-TODO: Explain the setting
-
-⚡ This setting is reactive: It automatically merges* any changes, during runtime, with the previous values  
-_* = Because it **merges** the previous values with the new values, it is not possible te remove values. This might change in the future_
-
-## Using the `persistDeviceBetweenDomain` setting
-When this setting is enabled, the library will create a cookie upon successfully registering the device.
-This cookie will have the current `deviceIdentification` as it's value and the `persistDeviceBetweenDomain` as it's `domain`.
-This way you can deploy the library on 2 different subdomains, but keep the same (anonymous) chat on both 
-(instead of having a new device registration, and thus a new chat, on the second subdomain).
-
-Here is an example:
-Let's say we have 2 domains: `domainA.example.com` and `domainB.example.com`
-We want our anonymous users to be able to start a chat on `domainA` and continue their chat on `domainB`.
-Currently, this won't work because the device information is stored in the localStorage which does not get shared between subdomains.
-If you set the `persistDeviceBetweenDomain` to `example.com`, and start a chat, your `deviceIdentification` will now be saved in a cookie
-that is readable by all subdomains. After starting a chat on `domainA`, you can navigate to `domainB` and the chat will
-recognize that there is a cookie and use the `deviceIdentification` stored in there.
-
-⚡ This setting is reactive: After changing this during runtime, a new device registration is created and the existing
-cookie will be overridden with the new `deviceIdentification` (if there is a new one)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "parley-web-library",
-	"version": "2.0.0-alpha.9",
+	"version": "2.0.0-alpha.10",
 	"description": "Front-end solution for Parley",
 	"private": true,
 	"targets": {


### PR DESCRIPTION
Bump version number for new release.
Moved the documentation to https://developers.parley.nu/docs/introduction-2 