### PR TITLE
Add authorization header for all api calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ ssl
 
 # Gitlink plugin
 /.idea/GitLink.xml
+
+# Env variables for cypress tests
+/cypress.env.json

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ You can find more info on how to enable WSL on windows 10 here: https://docs.mic
    ```bash
    chmod +x ./bin/start_cypress.sh
    ```
+6. Copy/Paste/Rename `cypress.env.json.example` to `cypress.env.json` and fill in the variables
+   - `authorizationHeader`: The authorization header used for tests where the client needs to log in. Can be acquired from https://admin.parley.nu/account/0cce5bfcdbf07978b269/settings/authorization
 #### Start
 ```
 npm run cy:open

--- a/cypress.ci.json
+++ b/cypress.ci.json
@@ -6,5 +6,8 @@
 		"reportFilename": "[name]-report",
 		"html": false,
 		"json": true
+	},
+	"retries": {
+		"runMode": 2
 	}
 }

--- a/cypress.env.json.example
+++ b/cypress.env.json.example
@@ -1,0 +1,3 @@
+{
+	"authorizationHeader": ""
+}

--- a/cypress/integration/api-class_spec.js
+++ b/cypress/integration/api-class_spec.js
@@ -643,17 +643,17 @@ describe("Api class", () => {
 			const testUrl = `/test/fetch/wrapper`;
 			const method = "GET";
 
-			cy.intercept(method, testUrl, {
-				statusCode: 200,
-				body: {},
+			cy.intercept(method, testUrl, (req) => {
+				expect(Object.keys(req.headers)).to.include.members(Object.keys(defaultHeaders));
+				expect(Object.values(req.headers)).to.include.members(Object.values(defaultHeaders));
+
+				req.reply({
+					statusCode: 200,
+					body: {},
+				});
 			}).as("fetchWrapper");
 
 			config.api.fetchWrapper(testUrl, {method});
-
-			cy.wait("@fetchWrapper").then((interception) => {
-				expect(Object.keys(interception.request.headers)).to.include.members(Object.keys(defaultHeaders));
-				expect(Object.values(interception.request.headers)).to.include.members(Object.values(defaultHeaders));
-			});
 		});
 		it("should make a request with custom headers", () => {
 			const customHeaders = {

--- a/cypress/integration/api-class_spec.js
+++ b/cypress/integration/api-class_spec.js
@@ -653,7 +653,7 @@ describe("Api class", () => {
 				});
 			}).as("fetchWrapper");
 
-			config.api.fetchWrapper(testUrl, {method});
+			cy.wrap(config.api.fetchWrapper(testUrl, {method}));
 		});
 		it("should make a request with custom headers", () => {
 			const customHeaders = {

--- a/cypress/integration/api-class_spec.js
+++ b/cypress/integration/api-class_spec.js
@@ -640,20 +640,15 @@ describe("Api class", () => {
 			config.api.setDeviceIdentification(config.deviceIdentification);
 			config.api.setAuthorization(config.authorization);
 
-			const testUrl = `/test/fetch/wrapper`;
-			const method = "GET";
-
-			cy.intercept(method, testUrl, (req) => {
-				expect(Object.keys(req.headers)).to.include.members(Object.keys(defaultHeaders));
-				expect(Object.values(req.headers)).to.include.members(Object.values(defaultHeaders));
-
-				req.reply({
-					statusCode: 200,
-					body: {},
-				});
-			}).as("fetchWrapper");
+			const testUrl = `${config.apiDomain}/**/devices`;
+			const method = "POST";
 
 			cy.wrap(config.api.fetchWrapper(testUrl, {method}));
+
+			cy.wait("@postDevices").then((interception) => {
+				expect(Object.keys(interception.request.headers)).to.include.members(Object.keys(defaultHeaders));
+				expect(Object.values(interception.request.headers)).to.include.members(Object.values(defaultHeaders));
+			});
 		});
 		it("should make a request with custom headers", () => {
 			const customHeaders = {

--- a/cypress/integration/api-class_spec.js
+++ b/cypress/integration/api-class_spec.js
@@ -144,8 +144,9 @@ describe("Api class", () => {
 
 			expect(config.api.config.apiDomain).to.be.equal(newDomain);
 		});
-		it("should throw an error when using something other than a String as domain", () => {
-			filterPrimitives(["string"]).forEach((set) => {
+
+		filterPrimitives(["string"]).forEach((set) => {
+			it(`should throw an error when using '${set.type}' as domain`, () => {
 				expect(() => config.api.setDomain(set.value))
 					.to.throw(`Expected \`apiDomain\` to be of type \`string\` but received type \`${set.type}\``);
 			});
@@ -163,8 +164,8 @@ describe("Api class", () => {
 
 			expect(config.api.accountIdentification).to.be.equal(newAccountIdentification);
 		});
-		it("should throw an error when using something other than a String as accountIdentification", () => {
-			filterPrimitives(["string"]).forEach((set) => {
+		filterPrimitives(["string"]).forEach((set) => {
+			it(`should throw an error when using '${set.type}' as accountIdentification`, () => {
 				expect(() => config.api.setAccountIdentification(set.value))
 					.to.throw(`Expected \`accountIdentification\` to be of type \`string\` but received type \`${set.type}\``);
 			});
@@ -182,8 +183,8 @@ describe("Api class", () => {
 
 			expect(config.api.deviceIdentification).to.be.equal(newDeviceIdentification);
 		});
-		it("should throw an error when using something other than a String as deviceIdentification", () => {
-			filterPrimitives(["string"]).forEach((set) => {
+		filterPrimitives(["string"]).forEach((set) => {
+			it(`should throw an error when using '${set.type}' as deviceIdentification`, () => {
 				expect(() => config.api.setDeviceIdentification(set.value))
 					.to.throw(`Expected \`deviceIdentification\` to be of type \`string\` but received type \`${set.type}\``);
 			});
@@ -200,6 +201,24 @@ describe("Api class", () => {
 		});
 	});
 
+	describe("setAuthorization()", () => {
+		it("should change the authorization", () => {
+			const newAuthorization = "somenewauthorization";
+			config.api.setAuthorization(newAuthorization);
+
+			expect(config.api.authorization).to.be.equal(newAuthorization);
+		});
+
+		filterPrimitives([
+			"string", "undefined",
+		]).forEach((set) => {
+			it(`should throw an error when using '${set.type}' as authorization`, () => {
+				expect(() => config.api.setAuthorization(set.value))
+					.to.throw(`Expected \`authorization\` to be of type \`string\` but received type \`${set.type}\``);
+			});
+		});
+	});
+
 	describe("setCustomHeaders()", () => {
 		it("should change the customHeaders", () => {
 			const newCustomHeaders = {
@@ -210,10 +229,10 @@ describe("Api class", () => {
 
 			expect(config.api.customHeaders).to.be.equal(newCustomHeaders);
 		});
-		it("should throw an error when using something other than an Object as customHeaders", () => {
-			filterPrimitives([
-				"Object", "undefined", "null", "boolean",
-			]).forEach((set) => {
+		filterPrimitives([
+			"Object", "undefined", "null", "boolean",
+		]).forEach((set) => {
+			it(`should throw an error when using '${set.type}' as customHeaders`, () => {
 				expect(() => config.api.setCustomHeaders(set.value))
 					.to.throw(`Expected \`customHeaders\` to be of type \`object\` but received type \`${set.type}\``);
 			});
@@ -242,14 +261,13 @@ describe("Api class", () => {
 	});
 
 	describe("subscribeDevice()", () => {
-		it("should throw an error when using something other than a String as pushToken", () => {
-			filterPrimitives([
-				"string",
-				"undefined", // Don't test for undefined, because pushToken is optional and if we give undefined it will test for `version` next
-			]).forEach((set) => {
+		filterPrimitives([
+			"string",
+			"undefined", // Don't test for undefined, because pushToken is optional and if we give undefined it will test for `version` next
+		]).forEach((set) => {
+			it(`should throw an error when using '${set.type}' as pushToken`, () => {
 				expect(() => config.api.subscribeDevice(
 					set.value,
-					undefined,
 					undefined,
 					undefined,
 					undefined,
@@ -261,15 +279,14 @@ describe("Api class", () => {
 			});
 		});
 
-		it("should throw an error when using something other than a Number as pushType", () => {
-			filterPrimitives([
-				"number",
-				"undefined", // Don't test for undefined, because pushType is optional and if we give undefined it will test for `version` next
-			]).forEach((set) => {
+		filterPrimitives([
+			"number",
+			"undefined", // Don't test for undefined, because pushType is optional and if we give undefined it will test for `version` next
+		]).forEach((set) => {
+			it(`should throw an error when using '${set.type}' as pushType`, () => {
 				expect(() => config.api.subscribeDevice(
 					config.pushToken,
 					set.value,
-					undefined,
 					undefined,
 					undefined,
 					undefined,
@@ -290,21 +307,19 @@ describe("Api class", () => {
 				undefined,
 				undefined,
 				undefined,
-				undefined,
 			))
 				.to.throw(`Expected number \`pushType\` to be one of \`[1,2,3,4,5,6]\`, got ${pushType}`);
 		});
 
-		it("should throw an error when using something other than a Boolean as pushEnabled", () => {
-			filterPrimitives([
-				"boolean",
-				"undefined", // Don't test for undefined, because pushEnabled is optional and if we give undefined it will test for `version` next
-			]).forEach((set) => {
+		filterPrimitives([
+			"boolean",
+			"undefined", // Don't test for undefined, because pushEnabled is optional and if we give undefined it will test for `version` next
+		]).forEach((set) => {
+			it(`should throw an error when using '${set.type}' as pushEnabled`, () => {
 				expect(() => config.api.subscribeDevice(
 					config.pushToken,
 					config.pushType,
 					set.value,
-					undefined,
 					undefined,
 					undefined,
 					undefined,
@@ -314,16 +329,15 @@ describe("Api class", () => {
 			});
 		});
 
-		it("should throw an error when using `pushEnabled = true` and something other than a String as pushToken", () => {
-			filterPrimitives([
-				"string",
-				"undefined", // Don't test for undefined, because pushToken is optional and if we give undefined it will test for `version` next
-			]).forEach((set) => {
+		filterPrimitives([
+			"string",
+			"undefined", // Don't test for undefined, because pushToken is optional and if we give undefined it will test for `version` next
+		]).forEach((set) => {
+			it(`should throw an error when using 'pushEnabled = true' and '${set.type}' as pushToken`, () => {
 				expect(() => config.api.subscribeDevice(
 					set.value,
 					config.pushType,
 					true,
-					undefined,
 					undefined,
 					undefined,
 					undefined,
@@ -333,17 +347,16 @@ describe("Api class", () => {
 			});
 		});
 
-		it("should throw an error when using something other than an Object as userAdditionalInformation", () => {
-			filterPrimitives([
-				"Object",
-				"undefined", // Don't test for undefined, because userAdditionalInformation is optional and if we give undefined it will test for `version` next
-			]).forEach((set) => {
+		filterPrimitives([
+			"Object",
+			"undefined", // Don't test for undefined, because userAdditionalInformation is optional and if we give undefined it will test for `version` next
+		]).forEach((set) => {
+			it(`should throw an error when using '${set.type}' as userAdditionalInformation`, () => {
 				expect(() => config.api.subscribeDevice(
 					config.pushToken,
 					config.pushType,
 					true,
 					set.value,
-					undefined,
 					undefined,
 					undefined,
 					undefined,
@@ -352,19 +365,18 @@ describe("Api class", () => {
 			});
 		});
 
-		it("should throw an error when using something other than a Number as type", () => {
-			filterPrimitives([
-				"number",
-				"boolean", // Boolean are numbers
-				"undefined", // Don't test for undefined, because type is optional and if we give undefined it will test for `version` next
-			]).forEach((set) => {
+		filterPrimitives([
+			"number",
+			"boolean", // Boolean are numbers
+			"undefined", // Don't test for undefined, because type is optional and if we give undefined it will test for `version` next
+		]).forEach((set) => {
+			it(`should throw an error when using '${set.type}' as type`, () => {
 				expect(() => config.api.subscribeDevice(
 					config.pushToken,
 					config.pushType,
 					true,
 					config.userAdditionalInformation,
 					set.value,
-					undefined,
 					undefined,
 					undefined,
 				))
@@ -382,13 +394,12 @@ describe("Api class", () => {
 				type,
 				undefined,
 				undefined,
-				undefined,
 			))
 				.to.throw(`Expected number \`type\` to be one of \`[1,2,3,4]\`, got ${type}`);
 		});
 
-		it("should throw an error when using something other than a String as version", () => {
-			filterPrimitives(["string"]).forEach((set) => {
+		filterPrimitives(["string"]).forEach((set) => {
+			it(`should throw an error when using '${set.type}' as version`, () => {
 				expect(() => config.api.subscribeDevice(
 					config.pushToken,
 					config.pushType,
@@ -396,7 +407,6 @@ describe("Api class", () => {
 					config.userAdditionalInformation,
 					config.type,
 					set.value,
-					undefined,
 					undefined,
 				))
 					.to.throw(`Expected \`version\` to be of type \`string\` but received type \`${set.type}\``);
@@ -414,7 +424,6 @@ describe("Api class", () => {
 				config.type,
 				shortVersion,
 				config.referer,
-				config.authorization,
 			))
 				.to.throw(`Expected string \`version\` to have a minimum length of \`5\`, got \`${shortVersion}\``);
 
@@ -428,7 +437,6 @@ describe("Api class", () => {
 				config.type,
 				longVersion,
 				config.referer,
-				config.authorization,
 			))
 				.to.throw(`Expected string \`version\` to have a maximum length of \`8\`, got \`${longVersion}\``);
 
@@ -442,16 +450,15 @@ describe("Api class", () => {
 				config.type,
 				wrongFormat,
 				config.referer,
-				config.authorization,
 			))
 				.to.throw(`Expected string \`version\` to match \`${DeviceVersionRegex}\`, got \`${wrongFormat}\``);
 		});
 
-		it("should throw an error when using something other than a String as referer", () => {
-			filterPrimitives([
-				"string",
-				"undefined",
-			]).forEach((set) => {
+		filterPrimitives([
+			"string",
+			"undefined",
+		]).forEach((set) => {
+			it(`should throw an error when using '${set.type}' as referer`, () => {
 				expect(() => config.api.subscribeDevice(
 					config.pushToken,
 					config.pushType,
@@ -460,28 +467,8 @@ describe("Api class", () => {
 					config.type,
 					config.version,
 					set.value,
-					config.authorization,
 				))
 					.to.throw(`Expected \`referer\` to be of type \`string\` but received type \`${set.type}\``);
-			});
-		});
-
-		it("should throw an error when using something other than a String as authorization", () => {
-			filterPrimitives([
-				"string",
-				"undefined", // Don't test for undefined, because authorization is optional and if we give undefined it will test for other params next
-			]).forEach((set) => {
-				expect(() => config.api.subscribeDevice(
-					config.pushToken,
-					config.pushType,
-					true,
-					config.userAdditionalInformation,
-					config.type,
-					config.version,
-					config.referer,
-					set.value,
-				))
-					.to.throw(`Expected \`authorization\` to be of type \`string\` but received type \`${set.type}\``);
 			});
 		});
 
@@ -495,7 +482,6 @@ describe("Api class", () => {
 				config.userAdditionalInformation,
 				config.type,
 				config.version,
-				undefined,
 				undefined,
 			);
 
@@ -525,7 +511,6 @@ describe("Api class", () => {
 						config.type,
 						config.version,
 						config.referer,
-						config.authorization,
 					);
 					expect(JSON.stringify(data)).to.be.equal(JSON.stringify(fixture));
 				});
@@ -550,7 +535,6 @@ describe("Api class", () => {
 							config.type,
 							config.version,
 							config.referer,
-							config.authorization,
 						);
 					});
 				});
@@ -570,7 +554,6 @@ describe("Api class", () => {
 				config.type,
 				config.version,
 				config.referer,
-				config.authorization,
 			).then(() => {
 				expect(config.api.isDeviceRegistrationPending).to.be.equal(false);
 				expect(config.api.deviceRegistered).to.be.equal(true);
@@ -581,18 +564,18 @@ describe("Api class", () => {
 	});
 
 	describe("sendMessage()", () => {
-		it("should throw an error when using something other than a String as message", () => {
-			filterPrimitives(["string"]).forEach((set) => {
+		filterPrimitives(["string"]).forEach((set) => {
+			it(`should throw an error when using '${set.type}' as message`, () => {
 				expect(() => config.api.sendMessage(set.value))
 					.to.throw(`Expected \`message\` to be of type \`string\` but received type \`${set.type}\``);
 			});
 		});
 
-		it("should throw an error when using something other than a String as referer", () => {
-			filterPrimitives([
-				"string",
-				"undefined",
-			]).forEach((set) => {
+		filterPrimitives([
+			"string",
+			"undefined",
+		]).forEach((set) => {
+			it(`should throw an error when using '${set.type}' as referer`, () => {
 				expect(() => config.api.sendMessage(
 					config.message,
 					set.value,
@@ -663,7 +646,6 @@ describe("Api class", () => {
 				config.type,
 				config.version,
 				config.referer,
-				config.authorization,
 			);
 
 			cy.wait("@postDevices").then((interception) => {
@@ -674,29 +656,29 @@ describe("Api class", () => {
 	});
 
 	describe("getMedia", () => {
-		it("should throw an error when using something other than a String as year", () => {
-			filterPrimitives(["string"]).forEach((set) => {
+		filterPrimitives(["string"]).forEach((set) => {
+			it(`should throw an error when using '${set.type}' as year`, () => {
 				expect(() => config.api.getMedia(set.value))
 					.to.throw(`Expected \`year\` to be of type \`string\` but received type \`${set.type}\``);
 			});
 		});
 
-		it("should throw an error when using something other than a String as month", () => {
-			filterPrimitives(["string"]).forEach((set) => {
+		filterPrimitives(["string"]).forEach((set) => {
+			it(`should throw an error when using '${set.type}' as month`, () => {
 				expect(() => config.api.getMedia("2023", set.value))
 					.to.throw(`Expected \`month\` to be of type \`string\` but received type \`${set.type}\``);
 			});
 		});
 
-		it("should throw an error when using something other than a String as day", () => {
-			filterPrimitives(["string"]).forEach((set) => {
+		filterPrimitives(["string"]).forEach((set) => {
+			it(`should throw an error when using '${set.type}' as day`, () => {
 				expect(() => config.api.getMedia("2023", "6", set.value))
 					.to.throw(`Expected \`day\` to be of type \`string\` but received type \`${set.type}\``);
 			});
 		});
 
-		it("should throw an error when using something other than a String as fileName", () => {
-			filterPrimitives(["string"]).forEach((set) => {
+		filterPrimitives(["string"]).forEach((set) => {
+			it(`should throw an error when using '${set.type}' as fileName`, () => {
 				expect(() => config.api.getMedia("2023", "6", "6", set.value))
 					.to.throw(`Expected \`fileName\` to be of type \`string\` but received type \`${set.type}\``);
 			});

--- a/cypress/integration/api-class_spec.js
+++ b/cypress/integration/api-class_spec.js
@@ -23,6 +23,7 @@ const config = {
 	message: "test message",
 	referer: "weblib-v2_cypress-test",
 	customHeaders: {},
+	authorization: "someauthorization",
 };
 const primitiveTypes = [
 	{
@@ -630,6 +631,30 @@ describe("Api class", () => {
 	});
 
 	describe("fetchWrapper()", () => {
+		it("should make a request with the default headers", () => {
+			const defaultHeaders = {
+				"x-iris-identification": `${config.accountIdentification}:${config.deviceIdentification}`,
+				authorization: config.authorization,
+			};
+
+			config.api.setDeviceIdentification(config.deviceIdentification);
+			config.api.setAuthorization(config.authorization);
+
+			const testUrl = `/test/fetch/wrapper`;
+			const method = "GET";
+
+			cy.intercept(method, testUrl, {
+				statusCode: 200,
+				body: {},
+			}).as("fetchWrapper");
+
+			config.api.fetchWrapper(testUrl, {method});
+
+			cy.wait("@fetchWrapper").then((interception) => {
+				expect(Object.keys(interception.request.headers)).to.include.members(Object.keys(defaultHeaders));
+				expect(Object.values(interception.request.headers)).to.include.members(Object.values(defaultHeaders));
+			});
+		});
 		it("should make a request with custom headers", () => {
 			const customHeaders = {
 				"x-custom-1": "1",

--- a/src/Api/Api.js
+++ b/src/Api/Api.js
@@ -243,14 +243,12 @@ export default class Api {
 			...options,
 		};
 
-		// Set the default headers that are used for all api calls
+		// Set the user defined custom and default headers that are used for all api calls
 		extendedOptions.headers = Object.assign(extendedOptions.headers, {
+			...this.customHeaders,
 			"x-iris-identification": `${this.accountIdentification}:${this.deviceIdentification}`,
 			Authorization: this.authorization || "",
 		});
-
-		// Set the user defined custom headers
-		extendedOptions.headers = Object.assign(extendedOptions.headers, this.customHeaders);
 
 		return new Promise((resolve, reject) => {
 			fetch(url, extendedOptions)

--- a/src/Api/Api.js
+++ b/src/Api/Api.js
@@ -24,7 +24,14 @@ import {error as ErrorStatus} from "./Constants/ApiResponseStatuses";
 import {CUSTOMHEADER_BLACKLIST} from "./Constants/CustomHeaderBlacklist";
 
 export default class Api {
-	constructor(apiDomain, accountIdentification, deviceIdentification, apiEventTarget, customHeaders) {
+	constructor(
+		apiDomain,
+		accountIdentification,
+		deviceIdentification,
+		apiEventTarget,
+		customHeaders,
+		authorization,
+	) {
 		ow(apiEventTarget, "apiEventTarget", ow.object.instanceOf(EventTarget));
 
 		// Rest of the validation is done in the setX() functions
@@ -32,6 +39,7 @@ export default class Api {
 		this.setAccountIdentification(accountIdentification);
 		this.setDeviceIdentification(deviceIdentification);
 		this.setCustomHeaders(customHeaders);
+		this.setAuthorization(authorization);
 		this.eventTarget = apiEventTarget;
 		this.deviceRegistered = false;
 		this.isDeviceRegistrationPending = false;
@@ -54,6 +62,12 @@ export default class Api {
 		ow(deviceIdentification, "deviceIdentification", ow.string.minLength(MinUdidLength));
 
 		this.deviceIdentification = deviceIdentification;
+	}
+
+	setAuthorization(authorization) {
+		ow(authorization, "authorization", ow.optional.string.nonEmpty);
+
+		this.authorization = authorization;
 	}
 
 	setCustomHeaders(customHeaders) {
@@ -97,7 +111,6 @@ export default class Api {
 	 * @param type
 	 * @param version
 	 * @param referer
-	 * @param authorization
 	 * @return {Promise<unknown>|boolean}
 	 */
 	subscribeDevice(
@@ -108,7 +121,6 @@ export default class Api {
 		type,
 		version,
 		referer,
-		authorization,
 	) {
 		// Validate params
 		ow(pushToken, "pushToken", ow.optional.string.nonEmpty);
@@ -124,7 +136,6 @@ export default class Api {
 		ow(version, "version", ow.string.maxLength(DeviceVersionMaxLength));
 		ow(version, "version", ow.string.matches(DeviceVersionRegex));
 		ow(referer, "referer", ow.optional.string.nonEmpty);
-		ow(authorization, "authorization", ow.optional.string.nonEmpty);
 
 		// If the referer isn't set, set it to the window's url
 		let refererCopy = referer;
@@ -135,10 +146,6 @@ export default class Api {
 
 		return this.fetchWrapper(`${this.config.apiUrl}/devices`, {
 			method: "POST",
-			headers: {
-				"x-iris-identification": `${this.accountIdentification}:${this.deviceIdentification}`,
-				Authorization: authorization || "",
-			},
 			body: JSON.stringify({
 				pushToken,
 				pushType,
@@ -147,7 +154,6 @@ export default class Api {
 				type,
 				version,
 				referer: refererCopy,
-				authorization,
 			}),
 		})
 			.then((data) => {
@@ -182,7 +188,6 @@ export default class Api {
 
 		return this.fetchWrapper(`${this.config.apiUrl}/messages`, {
 			method: "POST",
-			headers: {"x-iris-identification": `${this.accountIdentification}:${this.deviceIdentification}`},
 			body: JSON.stringify({
 				message,
 				referer: refererCopy,
@@ -202,10 +207,7 @@ export default class Api {
 	}
 
 	getMessages() {
-		return this.fetchWrapper(`${this.config.apiUrl}/messages`, {
-			method: "GET",
-			headers: {"x-iris-identification": `${this.accountIdentification}:${this.deviceIdentification}`},
-		})
+		return this.fetchWrapper(`${this.config.apiUrl}/messages`, {method: "GET"})
 			.then((data) => {
 				this.eventTarget.dispatchEvent(new ApiResponseEvent(messages, data));
 				return data;
@@ -225,10 +227,7 @@ export default class Api {
 		ow(day, "day", ow.string.nonEmpty);
 		ow(fileName, "fileName", ow.string.nonEmpty);
 
-		return this.fetchWrapper(`${this.config.apiUrl}/media/${year}/${month}/${day}/${fileName}`, {
-			method: "GET",
-			headers: {"x-iris-identification": `${this.accountIdentification}:${this.deviceIdentification}`},
-		})
+		return this.fetchWrapper(`${this.config.apiUrl}/media/${year}/${month}/${day}/${fileName}`, {method: "GET"})
 			.catch((errorNotifications, warningNotifications) => {
 				this.eventTarget.dispatchEvent(new ApiResponseEvent(media, {
 					errorNotifications,
@@ -239,11 +238,18 @@ export default class Api {
 	}
 
 	fetchWrapper(url, options) {
-		// Merge any custom headers into the already configured headers
 		const extendedOptions = {
 			headers: {}, // Headers must always exist
 			...options,
 		};
+
+		// Set the default headers that are used for all api calls
+		extendedOptions.headers = Object.assign(extendedOptions.headers, {
+			"x-iris-identification": `${this.accountIdentification}:${this.deviceIdentification}`,
+			Authorization: this.authorization || "",
+		});
+
+		// Set the user defined custom headers
 		extendedOptions.headers = Object.assign(extendedOptions.headers, this.customHeaders);
 
 		return new Promise((resolve, reject) => {

--- a/src/UI/App.jsx
+++ b/src/UI/App.jsx
@@ -199,6 +199,15 @@ export default class App extends React.Component {
 				return;
 			}
 		}
+
+		if(authorization !== this.Api.authorization) {
+			Logger.debug("Using new Authorization from now on", {
+				oldAuthorization: this.Api.authorization,
+				newAuthorization: authorization,
+			});
+			this.Api.setAuthorization(authorization);
+		}
+
 		Logger.debug("Registering new device");
 
 		// Store the device identification, so we don't generate a new one on each registration
@@ -212,7 +221,6 @@ export default class App extends React.Component {
 			type,
 			deviceVersion,
 			referer,
-			authorization,
 		)
 			.then(() => {
 				// Save registration in local storage
@@ -230,6 +238,7 @@ export default class App extends React.Component {
 				Logger.debug("Device registered, ", {
 					accountIdentification: this.Api.accountIdentification,
 					deviceIdentification: this.Api.deviceIdentification,
+					authorization: this.Api.authorization,
 				});
 			});
 	}
@@ -284,15 +293,12 @@ export default class App extends React.Component {
 		// and when userAdditionalInformation changes
 		const nextStateUserAdditionalInformation = JSON.stringify(nextState.userAdditionalInformation);
 		const stateUserAdditionalInformation = JSON.stringify(this.state.userAdditionalInformation);
-
 		if(nextState.deviceAuthorization !== this.state.deviceAuthorization
-			// eslint-disable-next-line max-len
 			|| nextStateUserAdditionalInformation !== stateUserAdditionalInformation
 		) {
 			if(nextState.deviceAuthorization !== this.state.deviceAuthorization)
 				Logger.debug("Device authorization changed, registering new device");
 
-			// eslint-disable-next-line max-len
 			if(nextStateUserAdditionalInformation !== stateUserAdditionalInformation)
 				Logger.debug("User additional information changed, registering new device");
 

--- a/src/UI/App.jsx
+++ b/src/UI/App.jsx
@@ -555,7 +555,7 @@ export default class App extends React.Component {
 			DeviceTypes.Web,
 			this.state.deviceVersion,
 			undefined,
-			undefined,
+			this.state.deviceAuthorization,
 			false,
 		);
 	}


### PR DESCRIPTION
fixes https://github.com/parley-messaging/web-library-v1/issues/317

This pull request adds the authorization header to all API calls. Previously it was only added for the POST /devices call. This caused problems when you tried to retrieve messages using the GET /message call **after** logging in.