### PR TITLE
Show error when trying to downgrade a logged-in device

### DIFF
--- a/cypress/e2e/ui_spec.js
+++ b/cypress/e2e/ui_spec.js
@@ -481,7 +481,7 @@ describe("UI", () => {
 				.should("be.visible")
 				.should("be.enabled");
 		});
-		it("should re-register after receiving the `deviceRequiresAuthorizationError` error", () => {
+		it("should re-register after receiving the `deviceRequiresAuthorizationError` error and close the error", () => {
 			const parleyConfig = {xIrisIdentification: "aaaaaaaaaaaa"};
 			const testMessage = `Test message ${Date.now()}`;
 
@@ -506,6 +506,7 @@ describe("UI", () => {
 				.find("[class^=chat__]")
 				.should("be.visible")
 				.find("[class^=error__]")
+				.as("error")
 				.should("be.visible")
 				.should("have.text", "This conversation is continued in a logged-in environment, go back to that environment if you want to continue the conversation. Send a new message below if you want to start a new conversation.");
 			cy.intercept("GET", "*/**/messages", req => req.continue()); // Reset the previous interceptor
@@ -528,6 +529,9 @@ describe("UI", () => {
 			sendMessage(testMessage);
 			cy.wait("@createDevice");
 			findMessage(testMessage);
+
+			cy.get("@error")
+				.should("not.exist");
 		});
 	});
 	describe("receiving messages", () => {

--- a/cypress/e2e/ui_spec.js
+++ b/cypress/e2e/ui_spec.js
@@ -893,6 +893,243 @@ describe("UI", () => {
 							.should("have.attr", "placeholder", newPlaceholder);
 					});
 				});
+				describe("ariaLabelButtonMenu", () => {
+					it("should change the text", () => {
+						const parleyConfig = {runOptions: {interfaceTexts: {ariaLabelButtonMinimize: "Custom text"}}};
+
+						visitHome(parleyConfig);
+						clickOnLauncher();
+
+						cy.get("@app")
+							.find("[class*=minimize__]")
+							.as("minimizeButton")
+							.should("have.attr", "aria-label")
+							.should("equal", parleyConfig.runOptions.interfaceTexts.ariaLabelButtonMinimize);
+
+						// Test if it changes during runtime
+						const newValue = "Custom text #2";
+						cy.window()
+							.then((win) => {
+								// eslint-disable-next-line no-param-reassign
+								win.parleySettings.runOptions.interfaceTexts.ariaLabelButtonMinimize = newValue;
+							});
+
+						cy.get("@minimizeButton")
+							.should("have.attr", "aria-label")
+							.should("equal", newValue);
+					});
+				});
+				describe("ariaLabelButtonLauncher", () => {
+					it("should change the text", () => {
+						const parleyConfig = {runOptions: {interfaceTexts: {ariaLabelButtonLauncher: "Custom text"}}};
+
+						visitHome(parleyConfig);
+						clickOnLauncher();
+
+						cy.get("@app")
+							.find("#launcher")
+							.as("elementUnderTest")
+							.should("have.attr", "aria-label")
+							.should("equal", parleyConfig.runOptions.interfaceTexts.ariaLabelButtonLauncher);
+
+						// Test if it changes during runtime
+						const newValue = "Custom text #2";
+						cy.window()
+							.then((win) => {
+								// eslint-disable-next-line no-param-reassign
+								win.parleySettings.runOptions.interfaceTexts.ariaLabelButtonLauncher = newValue;
+							});
+
+						cy.get("@elementUnderTest")
+							.should("have.attr", "aria-label")
+							.should("equal", newValue);
+					});
+				});
+				describe("ariaLabelButtonErrorClose", () => {
+					it("should change the text", () => {
+						const parleyConfig = {runOptions: {interfaceTexts: {ariaLabelButtonErrorClose: "Custom text"}}};
+
+						cy.intercept("POST", "*/**/messages", {
+							statusCode: 400,
+							body: {status: "ERROR"},
+						});
+
+						visitHome(parleyConfig);
+						clickOnLauncher();
+						sendMessage("test message");
+
+						cy.get("@app")
+							.find("[class^=error__]")
+							.find("button")
+							.as("elementUnderTest")
+							.should("have.attr", "aria-label")
+							.should("equal", parleyConfig.runOptions.interfaceTexts.ariaLabelButtonErrorClose);
+
+						// Test if it changes during runtime
+						const newValue = "Custom text #2";
+						cy.window()
+							.then((win) => {
+								// eslint-disable-next-line no-param-reassign
+								win.parleySettings.runOptions.interfaceTexts.ariaLabelButtonErrorClose = newValue;
+							});
+
+						cy.get("@elementUnderTest")
+							.should("have.attr", "aria-label")
+							.should("equal", newValue);
+					});
+				});
+				describe("ariaLabelTextInput", () => {
+					it("should change the text", () => {
+						const parleyConfig = {runOptions: {interfaceTexts: {ariaLabelTextInput: "Custom text"}}};
+
+						visitHome(parleyConfig);
+
+						clickOnLauncher();
+
+						cy.get("@app")
+							.find("[class^=text__]")
+							.find("textarea")
+							.as("elementUnderTest")
+							.should("have.attr", "aria-label")
+							.should("equal", parleyConfig.runOptions.interfaceTexts.ariaLabelTextInput);
+
+						// Test if it changes during runtime
+						const newValue = "Custom text #2";
+						cy.window()
+							.then((win) => {
+								// eslint-disable-next-line no-param-reassign
+								win.parleySettings.runOptions.interfaceTexts.ariaLabelTextInput = newValue;
+							});
+
+						cy.get("@elementUnderTest")
+							.should("have.attr", "aria-label")
+							.should("equal", newValue);
+					});
+				});
+				describe("retrievingMessagesFailedError", () => {
+					it("should change the text", () => {
+						const parleyConfig = {runOptions: {interfaceTexts: {retrievingMessagesFailedError: "Custom text"}}};
+
+						cy.intercept("GET", "*/**/messages", {
+							statusCode: 400,
+							body: {
+								status: "ERROR",
+								notifications: [
+									{
+										type: "error",
+										message: "Some specific error",
+									},
+								],
+							},
+						}).as("getMessages");
+
+						visitHome(parleyConfig);
+						clickOnLauncher();
+
+						cy.wait("@getMessages");
+
+						cy.get("@app")
+							.find("[class^=error__]")
+							.as("elementUnderTest")
+							.should("have.text", parleyConfig.runOptions.interfaceTexts.retrievingMessagesFailedError);
+
+						// Test if it changes during runtime
+						const newValue = "Custom text #2";
+						cy.window()
+							.then((win) => {
+								// eslint-disable-next-line no-param-reassign
+								win.parleySettings.runOptions.interfaceTexts.retrievingMessagesFailedError = newValue;
+							});
+
+						cy.get("@elementUnderTest")
+							.should("have.text", newValue);
+					});
+				});
+				describe("subscribeDeviceFailedError", () => {
+					it("should change the text", () => {
+						const parleyConfig = {runOptions: {interfaceTexts: {subscribeDeviceFailedError: "Custom text"}}};
+
+						cy.intercept("POST", "*/**/devices", {
+							statusCode: 400,
+							body: {
+								status: "ERROR",
+								notifications: [
+									{
+										type: "error",
+										message: "Some specific error",
+									},
+								],
+							},
+						})
+							.as("postDevices");
+
+						visitHome(parleyConfig);
+						clickOnLauncher();
+						cy.wait("@postDevices");
+
+						cy.get("@app")
+							.find("[class^=error__]")
+							.as("elementUnderTest")
+							.should("have.text", parleyConfig.runOptions.interfaceTexts.subscribeDeviceFailedError);
+
+						// Test if it changes during runtime
+						const newValue = "Custom text #2";
+						cy.window()
+							.then((win) => {
+								// eslint-disable-next-line no-param-reassign
+								win.parleySettings.runOptions.interfaceTexts.subscribeDeviceFailedError = newValue;
+							});
+
+						cy.get("@elementUnderTest")
+							.find("button")
+							.click(); // Close alert first
+						clickOnLauncher(); // Close chat
+						clickOnLauncher(); // Open chat
+						cy.wait("@postDevices");
+
+						cy.get("@elementUnderTest")
+							.should("have.text", newValue);
+					});
+				});
+				describe("serviceGenericError", () => {
+					it("should change the text", () => {
+						const parleyConfig = {runOptions: {interfaceTexts: {serviceGenericError: "Custom text"}}};
+
+						cy.intercept("POST", "*/**/messages", {
+							statusCode: 400,
+							body: {status: "ERROR"},
+						}).as("postMessage");
+
+						visitHome(parleyConfig);
+						clickOnLauncher();
+						sendMessage("test message");
+						cy.wait("@postMessage");
+
+						cy.get("@app")
+							.find("[class^=error__]")
+							.as("elementUnderTest")
+							.should("have.text", parleyConfig.runOptions.interfaceTexts.serviceGenericError);
+
+						// Test if it changes during runtime
+						const newValue = "Custom text #2";
+						cy.window()
+							.then((win) => {
+								// eslint-disable-next-line no-param-reassign
+								win.parleySettings.runOptions.interfaceTexts.serviceGenericError = newValue;
+							});
+
+						cy.get("@elementUnderTest")
+							.find("button")
+							.click(); // Close alert first
+						clickOnLauncher(); // Close chat
+						clickOnLauncher(); // Open chat
+						sendMessage("test message 2");
+						cy.wait("@postMessage");
+
+						cy.get("@elementUnderTest")
+							.should("have.text", newValue);
+					});
+				});
 				describe("deviceRequiresAuthorizationError", () => {
 					it("should change the error message", () => {
 						const parleyConfig = {runOptions: {interfaceTexts: {deviceRequiresAuthorizationError: "This is the deviceRequiresAuthorizationError text"}}};

--- a/cypress/e2e/ui_spec.js
+++ b/cypress/e2e/ui_spec.js
@@ -511,8 +511,7 @@ describe("UI", () => {
 				.should("have.text", "This conversation is continued in a logged-in environment, go back to that environment if you want to continue the conversation. Send a new message below if you want to start a new conversation.");
 			cy.intercept("GET", "*/**/messages", req => req.continue()); // Reset the previous interceptor
 
-			// Test that the identification changed and does not match the old identification
-			// anymore
+			// Test that the identification changed and does not match the old identification anymore
 			cy.intercept("POST", "*/**/devices", (req) => {
 				expect(req.headers)
 					.to
@@ -893,7 +892,7 @@ describe("UI", () => {
 							.should("have.attr", "placeholder", newPlaceholder);
 					});
 				});
-				describe("ariaLabelButtonMenu", () => {
+				describe("ariaLabelButtonMinimize", () => {
 					it("should change the text", () => {
 						const parleyConfig = {runOptions: {interfaceTexts: {ariaLabelButtonMinimize: "Custom text"}}};
 

--- a/src/UI/App.jsx
+++ b/src/UI/App.jsx
@@ -159,16 +159,21 @@ export default class App extends React.Component {
 	 * Because we keep the device identification in multiple places we need to decide which ones
 	 * have priority over the other locations. This function returns the device identification
 	 * from the place with the highest priority first and goes down in the list if needed
+	 * @param forceNew bool If true, it will create a new device identification
 	 * @return {string|*|string}
 	 */
-	getDeviceIdentification = () => {
+	getDeviceIdentification = (forceNew = false) => {
+		if(forceNew) {
+			Logger.debug("Forcing new device identification, so creating a new one.");
+			return ApiOptions.generateDeviceIdentification();
+		}
+
 		// First; If parleySettings has an identification, always use that
 		const parleySettingsIdentification = window?.parleySettings?.xIrisIdentification;
 		if(parleySettingsIdentification) {
 			Logger.debug("Found device identification in window.parleySettings.xIrisIdentification, so using that.");
 			return parleySettingsIdentification;
 		}
-
 
 		// Second; Get identification from cookie
 		// NOTE: It is not possible to check the expiry time from the cookie, so if it is expired
@@ -179,7 +184,6 @@ export default class App extends React.Component {
 			return cookieDeviceIdentification;
 		}
 
-
 		// Third; Get identification from localStorage
 		const localStorageIdentification = JSON.parse(localStorage.getItem("deviceInformation"))?.deviceIdentification;
 		if(localStorageIdentification) {
@@ -187,10 +191,9 @@ export default class App extends React.Component {
 			return localStorageIdentification;
 		}
 
-
 		// Last; Create a new identification
 		Logger.debug("No existing device identifications found, so creating a new one.");
-		return ApiOptions.deviceIdentification;
+		return ApiOptions.generateDeviceIdentification();
 	};
 
 	/**

--- a/src/UI/App.jsx
+++ b/src/UI/App.jsx
@@ -37,7 +37,7 @@ export default class App extends React.Component {
 		this.messageIDs = new Set();
 		this.visibilityChange = "visibilitychange";
 		this.cookieAgeRefreshIntervalId = null;
-		this.isMounted = false;
+		this._isMounted = false;
 
 		const interfaceLanguage = window?.parleySettings?.runOptions?.country || "en";
 		const interfaceTextsDefaults = interfaceLanguage === "nl" ? InterfaceTexts.dutch : InterfaceTexts.english;
@@ -169,7 +169,7 @@ export default class App extends React.Component {
 		if(forceNew) {
 			Logger.debug("Forcing new device identification, so creating a new one.");
 			const newDeviceIdentification = ApiOptions.generateDeviceIdentification();
-			this.isMounted && this.setState(() => ({deviceIdentification: newDeviceIdentification}));
+			this._isMounted && this.setState(() => ({deviceIdentification: newDeviceIdentification}));
 			return newDeviceIdentification;
 		}
 
@@ -184,7 +184,7 @@ export default class App extends React.Component {
 		const parleySettingsIdentification = window?.parleySettings?.xIrisIdentification;
 		if(parleySettingsIdentification) {
 			Logger.debug("Found device identification in window.parleySettings.xIrisIdentification, so using that.");
-			this.isMounted && this.setState(() => ({deviceIdentification: parleySettingsIdentification}));
+			this._isMounted && this.setState(() => ({deviceIdentification: parleySettingsIdentification}));
 			return parleySettingsIdentification;
 		}
 
@@ -194,7 +194,7 @@ export default class App extends React.Component {
 		const cookieDeviceIdentification = this.getDeviceIdentificationCookie();
 		if(cookieDeviceIdentification) {
 			Logger.debug("Found device identification in the device identification cookie, so using that.");
-			this.isMounted && this.setState(() => ({deviceIdentification: cookieDeviceIdentification}));
+			this._isMounted && this.setState(() => ({deviceIdentification: cookieDeviceIdentification}));
 			return cookieDeviceIdentification;
 		}
 
@@ -202,14 +202,14 @@ export default class App extends React.Component {
 		const localStorageIdentification = JSON.parse(localStorage.getItem("deviceInformation"))?.deviceIdentification;
 		if(localStorageIdentification) {
 			Logger.debug("Found device identification in the localStorage, so using that.");
-			this.isMounted && this.setState(() => ({deviceIdentification: localStorageIdentification}));
+			this._isMounted && this.setState(() => ({deviceIdentification: localStorageIdentification}));
 			return localStorageIdentification;
 		}
 
 		// Last; Create a new identification
 		const newDeviceIdentification = ApiOptions.generateDeviceIdentification();
 		Logger.debug("No existing device identifications found, so creating a new one.");
-		this.isMounted && this.setState(() => ({deviceIdentification: newDeviceIdentification}));
+		this._isMounted && this.setState(() => ({deviceIdentification: newDeviceIdentification}));
 		return newDeviceIdentification;
 	};
 
@@ -393,7 +393,7 @@ export default class App extends React.Component {
 	}
 
 	componentDidMount() {
-		this.isMounted = true;
+		this._isMounted = true;
 		this.checkWorkingHours();
 
 		ApiEventTarget.addEventListener(messages, this.handleNewMessage);
@@ -421,7 +421,7 @@ export default class App extends React.Component {
 	}
 
 	componentWillUnmount() {
-		this.isMounted = false;
+		this._isMounted = false;
 
 		ApiEventTarget.removeEventListener(messages, this.handleNewMessage);
 		ApiEventTarget.removeEventListener(subscribe, this.handleSubscribe);

--- a/src/UI/App.jsx
+++ b/src/UI/App.jsx
@@ -50,7 +50,9 @@ export default class App extends React.Component {
 			interfaceLanguage,
 			interfaceTexts: {
 				...interfaceTextsDefaults,
-				...window?.parleySettings?.runOptions?.interfaceTexts,
+				...this.loadInterfaceTextOverrides(Object.keys(interfaceTextsDefaults)),
+
+				// Below are all the overrides which have deprecated names
 				title: window?.parleySettings?.runOptions?.interfaceTexts
 					?.desc || interfaceTextsDefaults.title,
 				inputPlaceholder: window?.parleySettings?.runOptions?.interfaceTexts
@@ -108,6 +110,36 @@ export default class App extends React.Component {
 		window.showParleyMessenger = this.showChat;
 
 		Logger.debug("App initialized");
+	}
+
+	/**
+	 * Returns the `window.parleySettings.runOptions.interfaceTexts`, but only with the
+	 * texts that are overridable. The texts that are overridable are given by
+	 * the `overridableTextsKeys` param.
+	 *
+	 * The problem this function solves is when you load in all
+	 * `window.parleySettings.runOptions.interfaceTexts` you will also load in their deprecated
+	 * names (if used). These deprecated names are not used anymore internally in the state,
+	 * so we have separate import rules for these texts.
+	 *
+	 * An example is `window.parleySettings.runOptions.interfaceTexts.desc`, this is internally
+	 * used as `state.interfaceTexts.title`, so we can't just import it without renaming it.
+	 * `desc` will be seen as non-overridable and thus won't be returned by this function.
+	 * @param {[]} overridableTextsKeys
+	 * @return {[]} An object containing the interfaceTexts (and their values) which can be used
+	 * to override the default texts.
+	 */
+	loadInterfaceTextOverrides = (overridableTextsKeys) => {
+		const overridesFromWindow = {...window?.parleySettings?.runOptions?.interfaceTexts};
+
+		// Remove all keys that are not overridable
+		Object.keys(overridesFromWindow).forEach((key) => {
+			if(!overridableTextsKeys.includes(key))
+				delete overridesFromWindow[key];
+		});
+
+		console.log(overridesFromWindow);
+		return overridesFromWindow;
 	}
 
 	/**

--- a/src/UI/App.jsx
+++ b/src/UI/App.jsx
@@ -138,7 +138,6 @@ export default class App extends React.Component {
 				delete overridesFromWindow[key];
 		});
 
-		console.log(overridesFromWindow);
 		return overridesFromWindow;
 	}
 

--- a/src/UI/App.jsx
+++ b/src/UI/App.jsx
@@ -50,6 +50,7 @@ export default class App extends React.Component {
 			interfaceLanguage,
 			interfaceTexts: {
 				...interfaceTextsDefaults,
+				...window?.parleySettings?.runOptions?.interfaceTexts,
 				title: window?.parleySettings?.runOptions?.interfaceTexts
 					?.desc || interfaceTextsDefaults.title,
 				inputPlaceholder: window?.parleySettings?.runOptions?.interfaceTexts

--- a/src/UI/Chat.jsx
+++ b/src/UI/Chat.jsx
@@ -201,7 +201,9 @@ class Chat extends Component {
 				{
 					this.state.errorNotification && this.state.errorNotification.length > 0
 					&& <div className={styles.error}>
-						{this.state.errorNotification}
+						<span className={styles.errorText}>
+							{this.state.errorNotification}
+						</span>
 						<button
 							aria-label={this.context.ariaLabelButtonErrorClose}
 							className={styles.closeButton}

--- a/src/UI/Chat.jsx
+++ b/src/UI/Chat.jsx
@@ -137,7 +137,7 @@ class Chat extends Component {
 		let error = defaultError || event.detail.errorNotifications[0];
 
 		if(event.detail.errorNotifications[0] === ApiGenericError) {
-			error = ApiGenericError;
+			error = this.context.serviceGenericError;
 		} else if(event.detail.errorNotifications[0] === ApiFetchFailed) {
 			// This is an error due to the service being unreachable
 			error = this.context.serviceUnreachableError;

--- a/src/UI/Chat.module.css
+++ b/src/UI/Chat.module.css
@@ -39,30 +39,30 @@
 }
 
 .error {
+	display: flex;
 	width: inherit;
 	box-sizing: border-box; /* Prevents padding from growing outward */
+	flex-direction: row;
+	align-items: center;
 	padding: 0.25em;
 	background-color: var(--parley-error-background-color, #4A5E83);
 	color: var(--parley-error-text-color, #FFF);
-	text-align: center;
-	display: flex;
-	flex-direction: row;
 	overflow-wrap: anywhere;
-	align-items: center;
+	text-align: center;
 }
 
 .closeButton {
-	flex: initial;
 	display: block;
 	width: 36px;
 	height: 100%;
+	flex: initial;
 	border: none;
+	margin-left: auto; /* Makes sure the button is always completely to the right */
 	background-color: transparent;
 	color: var(--parley-button-label-color, #FFF);
 	cursor: pointer;
 	float: right;
 	font-size: 24px;
-	margin-left: auto; /* Makes sure the button is always completely to the right */
 }
 
 .errorText {

--- a/src/UI/Chat.module.css
+++ b/src/UI/Chat.module.css
@@ -44,6 +44,8 @@
 	background-color: var(--parley-error-background-color, #4A5E83);
 	color: var(--parley-error-text-color, #FFF);
 	text-align: center;
+	display: flex;
+	flex-direction: row;
 }
 
 .closeButton {

--- a/src/UI/Chat.module.css
+++ b/src/UI/Chat.module.css
@@ -48,9 +48,11 @@
 	display: flex;
 	flex-direction: row;
 	overflow-wrap: anywhere;
+	align-items: center;
 }
 
 .closeButton {
+	flex: initial;
 	display: block;
 	width: 36px;
 	height: 100%;
@@ -61,4 +63,8 @@
 	float: right;
 	font-size: 24px;
 	margin-left: auto; /* Makes sure the button is always completely to the right */
+}
+
+.errorText {
+	flex: auto;
 }

--- a/src/UI/Chat.module.css
+++ b/src/UI/Chat.module.css
@@ -39,13 +39,15 @@
 }
 
 .error {
-	max-width: 100%;
+	width: inherit;
+	box-sizing: border-box; /* Prevents padding from growing outward */
 	padding: 0.25em;
 	background-color: var(--parley-error-background-color, #4A5E83);
 	color: var(--parley-error-text-color, #FFF);
 	text-align: center;
 	display: flex;
 	flex-direction: row;
+	overflow-wrap: anywhere;
 }
 
 .closeButton {
@@ -58,4 +60,5 @@
 	cursor: pointer;
 	float: right;
 	font-size: 24px;
+	margin-left: auto; /* Makes sure the button is always completely to the right */
 }

--- a/src/UI/Header.module.css
+++ b/src/UI/Header.module.css
@@ -1,7 +1,7 @@
 .header {
-	width: inherit;
 	top: 0;
 	display: grid;
+	width: inherit;
 	margin: 0;
 	background-color: var(--parley-nav-background-color, #4A5E83);
 	border-radius: 5px 5px 0 0;

--- a/src/UI/Header.module.css
+++ b/src/UI/Header.module.css
@@ -1,4 +1,5 @@
 .header {
+	width: inherit;
 	top: 0;
 	display: grid;
 	margin: 0;

--- a/src/UI/ReplyActions.jsx
+++ b/src/UI/ReplyActions.jsx
@@ -34,7 +34,7 @@ class ReplyActions extends Component {
 			// Wait until device is subscribed before trying to send a message
 			ApiEventTarget.addEventListener(subscribe, this.handleSubscribe);
 
-			this.props.subscribeDevice();
+			this.props.onDeviceNeedsSubscribing();
 		}
 	}
 
@@ -51,6 +51,8 @@ class ReplyActions extends Component {
 		.then(() => {
 			// Reset state
 			this.setState(() => ({reply: ""}));
+
+			this.props.onSentSuccessfully();
 		})
 		.finally(() => {
 			this.props.replyTextRef.current.textArea.current.disabled = false;
@@ -95,9 +97,10 @@ ReplyActions.propTypes = {
 	api: PropTypes.instanceOf(Api),
 	fitToIDeviceScreen: PropTypes.func,
 	isMobile: PropTypes.bool,
+	onDeviceNeedsSubscribing: PropTypes.func,
+	onSentSuccessfully: PropTypes.func,
 	replyTextRef: PropTypes.object,
 	restartPolling: PropTypes.func,
-	subscribeDevice: PropTypes.func,
 };
 
 export default React.forwardRef((props, ref) => <ReplyActions replyTextRef={ref} {...props} />);

--- a/src/UI/ReplyActions.jsx
+++ b/src/UI/ReplyActions.jsx
@@ -33,6 +33,8 @@ class ReplyActions extends Component {
 		} else {
 			// Wait until device is subscribed before trying to send a message
 			ApiEventTarget.addEventListener(subscribe, this.handleSubscribe);
+
+			this.props.subscribeDevice();
 		}
 	}
 
@@ -95,6 +97,7 @@ ReplyActions.propTypes = {
 	isMobile: PropTypes.bool,
 	replyTextRef: PropTypes.object,
 	restartPolling: PropTypes.func,
+	subscribeDevice: PropTypes.func,
 };
 
 export default React.forwardRef((props, ref) => <ReplyActions replyTextRef={ref} {...props} />);

--- a/src/UI/Scripts/Context.js
+++ b/src/UI/Scripts/Context.js
@@ -24,6 +24,7 @@ export const InterfaceTexts = {
 		messageRetrieveFailed: "Something went wrong while retrieving your messages, please try again later",
 		deviceRegistrationFailed: "Something went wrong while registering your device, please try again later",
 		serviceGenericError: "Something went wrong, please try again later",
+		deviceRequiresAuthorizationError: "This conversation is continued in a logged-in environment, go back to that environment if you want to continue the conversation. Send a new message below if you want to start a new conversation.",
 
 		// Old from v1 (but renamed)
 		title: "Messenger", // Was `desc`
@@ -45,6 +46,7 @@ export const InterfaceTexts = {
 		messageRetrieveFailed: "Er ging iets fout bij het ophalen van je berichten, probeer het later opnieuw",
 		deviceRegistrationFailed: "Er ging iets fout bij het registreren van je apparaat, probeer het later opnieuw",
 		serviceGenericError: "Er ging iets fout, probeer het later opnieuw",
+		deviceRequiresAuthorizationError: "Dit gesprek is verdergegaan in een ingelogde omgeving, wil je verder met dat gesprek ga dan terug naar die omgeving. Wil je een nieuw gesprek starten, stuur dan hieronder je bericht.",
 
 		// Old from v1 (but renamed)
 		title: "Messenger", // Was `desc`

--- a/src/UI/Scripts/Context.js
+++ b/src/UI/Scripts/Context.js
@@ -21,8 +21,6 @@ export const InterfaceTexts = {
 		ariaLabelButtonLauncher: "toggle chat window visibility",
 		ariaLabelButtonErrorClose: "hide error",
 		ariaLabelTextInput: "message ariaLabelTextInput field",
-		messageRetrieveFailed: "Something went wrong while retrieving your messages, please try again later",
-		deviceRegistrationFailed: "Something went wrong while registering your device, please try again later",
 		serviceGenericError: "Something went wrong, please try again later",
 		deviceRequiresAuthorizationError: "This conversation is continued in a logged-in environment, go back to that environment if you want to continue the conversation. Send a new message below if you want to start a new conversation.",
 
@@ -43,8 +41,6 @@ export const InterfaceTexts = {
 		ariaLabelButtonLauncher: "chat scherm zichtbaarheid schakelen",
 		ariaLabelButtonErrorClose: "verberg foutmelding",
 		ariaLabelTextInput: "bericht invoerveld",
-		messageRetrieveFailed: "Er ging iets fout bij het ophalen van je berichten, probeer het later opnieuw",
-		deviceRegistrationFailed: "Er ging iets fout bij het registreren van je apparaat, probeer het later opnieuw",
 		serviceGenericError: "Er ging iets fout, probeer het later opnieuw",
 		deviceRequiresAuthorizationError: "Dit gesprek is verdergegaan in een ingelogde omgeving, wil je verder met dat gesprek ga dan terug naar die omgeving. Wil je een nieuw gesprek starten, stuur dan hieronder je bericht.",
 

--- a/src/UI/Scripts/Context.js
+++ b/src/UI/Scripts/Context.js
@@ -4,7 +4,7 @@ import {v4 as uuidv4} from "uuid";
 export const ApiOptions = {
 	userAdditionalInformation: {},
 	accountIdentification: "0cce5bfcdbf07978b269",
-	deviceIdentification: JSON.parse(localStorage.getItem("deviceInformation"))?.deviceIdentification || uuidv4(),
+	generateDeviceIdentification: uuidv4,
 	apiDomain: "https://api.parley.nu",
 	autHeader: undefined,
 };


### PR DESCRIPTION
This PR fixes an issue where your (anonymous) chat would show empty messages when you had another chat that was logged-in on a different subdomain (using the `devicePersistence.domain` setting).

When this happens we show an error saying 
```
This conversation is continued in a logged-in environment, go back to that environment if you want to continue the conversation. Send a new message below if you want to start a new conversation.
```

Once the client sends a new message, we create a new registration for this device so it is no longer "connected" to the logged-in session on the other domain.

I also added a fix for overriding the interface texts defined in https://github.com/parley-messaging/web-library/blob/fa501a027fd3971f8f498b6f397f23ac56d34b99/src/UI/Scripts/Context.js#L16-L35. Previously you could only change
- `title` (using `window.parleySettings.runOptions.interfaceTexts.desc`)
- `inputPlaceholder` (using `window.parleySettings.runOptions.interfaceTexts.placeholderMessenger`)
- `sendingMessageFailedError` (using `window.parleySettings.runOptions.interfaceTexts.messageSendFailed`)
- `serviceUnreachableError` (using `window.parleySettings.runOptions.interfaceTexts.serviceUnreachableNotification`)
- `welcomeMessage` (using `window.parleySettings.runOptions.interfaceTexts.infoText`)

(The window setting names are taken from web-library v1 for backwards compatibility, so that is why they are not the same as the internal names)

You can now override every interface text defined in https://github.com/parley-messaging/web-library/blob/fa501a027fd3971f8f498b6f397f23ac56d34b99/src/UI/Scripts/Context.js#L16-L3 using `window.parleySettings.runOptions.interfaceTexts.[NAME OF THE TEXT]`.