### PR TITLE
Fix merging issue with weekdays

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"ui-for-watcher": {
 			"distDir": "dist/",
 			"optimize": false,
-			"sourceMap": false
+			"sourceMap": true
 		},
 		"ui-minimized": {
 			"distDir": "dist/ui/minified",

--- a/src/UI/App.jsx
+++ b/src/UI/App.jsx
@@ -133,13 +133,14 @@ export default class App extends React.Component {
 		const overridesFromWindow = {...window?.parleySettings?.runOptions?.interfaceTexts};
 
 		// Remove all keys that are not overridable
-		Object.keys(overridesFromWindow).forEach((key) => {
-			if(!overridableTextsKeys.includes(key))
-				delete overridesFromWindow[key];
-		});
+		Object.keys(overridesFromWindow)
+			.forEach((key) => {
+				if(!overridableTextsKeys.includes(key))
+					delete overridesFromWindow[key];
+			});
 
 		return overridesFromWindow;
-	}
+	};
 
 	/**
 	 * Creates a new cookie with that stores the device identification
@@ -594,6 +595,22 @@ export default class App extends React.Component {
 		} else if(path[layer0] === "authHeader") {
 			objectToSaveIntoState = {deviceAuthorization: value};
 		} else if(path[layer0] === "weekdays") {
+			// Find existing weekdays that have the same day name as the new value
+			// If we find any we delete them so the new setting can override them.
+			value.forEach((newWeekday) => {
+				const existingWeekday = this.state.workingHours?.find((stateWeekday) => {
+					if(stateWeekday[0].toLowerCase !== undefined) {
+						// Dealing with ["Day", start, end]
+						return stateWeekday[0].toLowerCase() === newWeekday[0].toLowerCase();
+					}
+
+					// Dealing with [startTimestamp, endTimestamp]
+					return stateWeekday[0] === newWeekday[0];
+				});
+				if(existingWeekday)
+					this.state.workingHours.splice(this.state.workingHours.indexOf(existingWeekday), 1);
+			});
+
 			objectToSaveIntoState = {workingHours: value};
 		} else if(path[layer0] === "xIrisIdentification") {
 			objectToSaveIntoState = {deviceIdentification: value};
@@ -796,7 +813,7 @@ export default class App extends React.Component {
 
 		// This will trigger a new subscribe due to state.deviceIdentification being updated
 		this.getDeviceIdentification(true);
-	}
+	};
 
 	/**
 	 * Called when, somehow, the device is not yet registered when trying to send

--- a/src/UI/App.jsx
+++ b/src/UI/App.jsx
@@ -789,8 +789,9 @@ export default class App extends React.Component {
 	};
 
 	checkWorkingHours = () => {
-		this.setState(prevState => ({offline: !areWeOnline(prevState.workingHours)}));
-		Logger.debug(`Offline mode ${this.state.offline ? "enabled" : "disabled"}`);
+		this.setState(prevState => ({offline: !areWeOnline(prevState.workingHours)}), () => {
+			Logger.debug(`Offline mode ${this.state.offline ? "enabled" : "disabled"}`);
+		});
 	};
 
 	saveMessengerOpenState = (messengerOpenState) => {


### PR DESCRIPTION
The problem is that `deepMerge` was adding the 2 arrays together. When you executed `window.parleySettings.weekdays = [["Monday", 0.00, 1.00]]` twice, you ended up with this in your state `[["Monday", 0.00, 1.00], ["Monday", 0.00, 1.00]]`. To fix this is added some code that looks at the value for the first index for each entry. If this value already exists in the state we remove it. This way you cannot have duplicates. This also works for the `[timestamp, timestamp]` format.

I don't think this bug caused any issues, because the last weekday was always the last one that was set by the client. So even though the state showed we had 3x a "Monday" setting, the last one was the one that overrides all the previous ones. This also makes it so we can't really test for this bug, unless we look at the internal `state` of the `App.jsx` component.