### PR TITLE
Fix interfaceTexts override issue

### DIFF
--- a/cypress/e2e/ui_spec.js
+++ b/cypress/e2e/ui_spec.js
@@ -1281,6 +1281,34 @@ describe("UI", () => {
 							.should("have.text", newTitle);
 					});
 				});
+				describe("title (new name for 'desc')", () => {
+					it("should change the title text", () => {
+						const parleyConfig = {runOptions: {interfaceTexts: {title: "This is the title bar"}}};
+
+						visitHome(parleyConfig);
+
+						cy.get("[id=app]")
+							.as("app");
+
+						clickOnLauncher();
+
+						cy.get("@app")
+							.find("[class^=parley-messaging-title__]")
+							.should("have.text", parleyConfig.runOptions.interfaceTexts.title);
+
+						// Test if it changes during runtime
+						const newTitle = "This is the title bar #2";
+						cy.window()
+							.then((win) => {
+								// eslint-disable-next-line no-param-reassign
+								win.parleySettings.runOptions.interfaceTexts.desc = newTitle;
+							});
+
+						cy.get("@app")
+							.find("[class^=parley-messaging-title__]")
+							.should("have.text", newTitle);
+					});
+				});
 				describe("infoText", () => {
 					it("should change the welcome message", () => {
 						const parleyConfig = {runOptions: {interfaceTexts: {infoText: "This is the info text"}}};
@@ -1376,6 +1404,46 @@ describe("UI", () => {
 							.should("not.exist");
 					});
 				});
+				describe("welcomeMessage (new name for 'infoText')", () => {
+					it("should change the welcome message", () => {
+						const parleyConfig = {runOptions: {interfaceTexts: {welcomeMessage: "This is the info text"}}};
+
+						// To test this we need to ignore the API's `welcomeMessage`
+						cy.fixture("getMessagesResponse.json")
+							.then((json) => {
+								const _json = {
+									...json,
+									welcomeMessage: null,
+								};
+								cy.intercept("GET", "*/**/messages", _json);
+							});
+
+						visitHome(parleyConfig);
+
+						cy.get("[id=app]")
+							.as("app");
+
+						clickOnLauncher();
+
+						cy.get("@app")
+							.find("[class*=parley-messaging-announcement__]")
+							.first()
+							.should("have.text", parleyConfig.runOptions.interfaceTexts.welcomeMessage);
+
+						// Test if it changes during runtime
+						const newValue = "This is the info text #2";
+						cy.window()
+							.then((win) => {
+								// eslint-disable-next-line no-param-reassign
+								win.parleySettings.runOptions.interfaceTexts.welcomeMessage = newValue;
+							});
+
+						cy.get("@app")
+							.find("[class*=parley-messaging-announcement__]")
+							.first()
+							.should("have.text", newValue);
+					});
+				});
 				describe("placeholderMessenger", () => {
 					it("should change the input's placeholder text", () => {
 						const parleyConfig = {runOptions: {interfaceTexts: {placeholderMessenger: "This is the placeholder"}}};
@@ -1398,6 +1466,36 @@ describe("UI", () => {
 							.then((win) => {
 								// eslint-disable-next-line no-param-reassign
 								win.parleySettings.runOptions.interfaceTexts.placeholderMessenger = newPlaceholder;
+							});
+
+						cy.get("@app")
+							.find("[class^=parley-messaging-text__]")
+							.find("textarea")
+							.should("have.attr", "placeholder", newPlaceholder);
+					});
+				});
+				describe("inputPlaceholder (new name for 'placeholderMessenger')", () => {
+					it("should change the input's placeholder text", () => {
+						const parleyConfig = {runOptions: {interfaceTexts: {inputPlaceholder: "This is the placeholder"}}};
+
+						visitHome(parleyConfig);
+
+						cy.get("[id=app]")
+							.as("app");
+
+						clickOnLauncher();
+
+						cy.get("@app")
+							.find("[class^=parley-messaging-text__]")
+							.find("textarea")
+							.should("have.attr", "placeholder", parleyConfig.runOptions.interfaceTexts.inputPlaceholder);
+
+						// Test if it changes during runtime
+						const newPlaceholder = "This is the placeholder #2";
+						cy.window()
+							.then((win) => {
+								// eslint-disable-next-line no-param-reassign
+								win.parleySettings.runOptions.interfaceTexts.inputPlaceholder = newPlaceholder;
 							});
 
 						cy.get("@app")
@@ -1721,6 +1819,144 @@ describe("UI", () => {
 						cy.get("@uploadLabel")
 							.should("have.attr", "aria-label")
 							.should("equal", newValue);
+					});
+				});
+				describe("messageSendFailed", () => {
+					it("should change the text", () => {
+						const parleyConfig = {runOptions: {interfaceTexts: {messageSendFailed: "Custom text"}}};
+						const testMessage = `Test message ${Date.now()}`;
+
+						cy.intercept("POST", "*/**/messages", {
+							statusCode: 400,
+							body: {
+								status: "ERROR",
+								notifications: [
+									{
+										type: "error",
+										message: "Some specific error",
+									},
+								],
+							},
+						});
+						visitHome(parleyConfig);
+						clickOnLauncher();
+						sendMessage(testMessage);
+
+						cy.get("@app")
+							.find("[class^=parley-messaging-error__]")
+							.should("have.text", parleyConfig.runOptions.interfaceTexts.messageSendFailed);
+
+						// Test if it changes during runtime
+						const newValue = "Custom text #2";
+						cy.window()
+							.then((win) => {
+								// eslint-disable-next-line no-param-reassign
+								win.parleySettings.runOptions.interfaceTexts.messageSendFailed = newValue;
+							});
+
+						sendMessage(testMessage);
+
+						cy.get("@app")
+							.find("[class^=parley-messaging-error__]")
+							.should("have.text", newValue);
+					});
+				});
+				describe("sendingMessageFailedError (new name for 'messageSendFailed')", () => {
+					it("should change the text", () => {
+						const parleyConfig = {runOptions: {interfaceTexts: {sendingMessageFailedError: "Custom text"}}};
+						const testMessage = `Test message ${Date.now()}`;
+
+						cy.intercept("POST", "*/**/messages", {
+							statusCode: 400,
+							body: {
+								status: "ERROR",
+								notifications: [
+									{
+										type: "error",
+										message: "Some specific error",
+									},
+								],
+							},
+						});
+						visitHome(parleyConfig);
+						clickOnLauncher();
+						sendMessage(testMessage);
+
+						cy.get("@app")
+							.find("[class^=parley-messaging-error__]")
+							.should("have.text", parleyConfig.runOptions.interfaceTexts.sendingMessageFailedError);
+
+						// Test if it changes during runtime
+						const newValue = "Custom text #2";
+						cy.window()
+							.then((win) => {
+								// eslint-disable-next-line no-param-reassign
+								win.parleySettings.runOptions.interfaceTexts.sendingMessageFailedError = newValue;
+							});
+
+						sendMessage(testMessage);
+
+						cy.get("@app")
+							.find("[class^=parley-messaging-error__]")
+							.should("have.text", newValue);
+					});
+				});
+				describe("serviceUnreachableNotification", () => {
+					it("should change the text", () => {
+						const parleyConfig = {runOptions: {interfaceTexts: {serviceUnreachableNotification: "Custom text"}}};
+						const testMessage = `Test message ${Date.now()}`;
+
+						cy.intercept("POST", "*/**/messages", {forceNetworkError: true});
+						visitHome(parleyConfig);
+						clickOnLauncher();
+						sendMessage(testMessage);
+
+						cy.get("@app")
+							.find("[class^=parley-messaging-error__]")
+							.should("have.text", parleyConfig.runOptions.interfaceTexts.serviceUnreachableNotification);
+
+						// Test if it changes during runtime
+						const newValue = "Custom text #2";
+						cy.window()
+							.then((win) => {
+								// eslint-disable-next-line no-param-reassign
+								win.parleySettings.runOptions.interfaceTexts.serviceUnreachableNotification = newValue;
+							});
+
+						sendMessage(testMessage);
+
+						cy.get("@app")
+							.find("[class^=parley-messaging-error__]")
+							.should("have.text", newValue);
+					});
+				});
+				describe("serviceUnreachableError (new name for 'serviceUnreachableNotification')", () => {
+					it("should change the text", () => {
+						const parleyConfig = {runOptions: {interfaceTexts: {serviceUnreachableError: "Custom text"}}};
+						const testMessage = `Test message ${Date.now()}`;
+
+						cy.intercept("POST", "*/**/messages", {forceNetworkError: true});
+						visitHome(parleyConfig);
+						clickOnLauncher();
+						sendMessage(testMessage);
+
+						cy.get("@app")
+							.find("[class^=parley-messaging-error__]")
+							.should("have.text", parleyConfig.runOptions.interfaceTexts.serviceUnreachableError);
+
+						// Test if it changes during runtime
+						const newValue = "Custom text #2";
+						cy.window()
+							.then((win) => {
+								// eslint-disable-next-line no-param-reassign
+								win.parleySettings.runOptions.interfaceTexts.serviceUnreachableError = newValue;
+							});
+
+						sendMessage(testMessage);
+
+						cy.get("@app")
+							.find("[class^=parley-messaging-error__]")
+							.should("have.text", newValue);
 					});
 				});
 			});

--- a/src/UI/App.jsx
+++ b/src/UI/App.jsx
@@ -49,10 +49,10 @@ export default class App extends React.Component {
 			isiOSMobile: isiOSMobileDevice(),
 			interfaceLanguage,
 			interfaceTexts: {
+				// Load the default values
 				...interfaceTextsDefaults,
-				...this.loadInterfaceTextOverrides(Object.keys(interfaceTextsDefaults)),
 
-				// Below are all the overrides which have deprecated names
+				// Load all the overrides which have deprecated names
 				title: window?.parleySettings?.runOptions?.interfaceTexts
 					?.desc || interfaceTextsDefaults.title,
 				inputPlaceholder: window?.parleySettings?.runOptions?.interfaceTexts
@@ -63,6 +63,9 @@ export default class App extends React.Component {
 					?.serviceUnreachableNotification || interfaceTextsDefaults.serviceUnreachableError,
 				welcomeMessage: window?.parleySettings?.runOptions?.interfaceTexts
 					?.infoText || interfaceTextsDefaults.welcomeMessage,
+
+				// Load all other overrides
+				...this.loadInterfaceTextOverrides(Object.keys(interfaceTextsDefaults)),
 			},
 			apiDomain: window?.parleySettings?.apiDomain || ApiOptions.apiDomain,
 			accountIdentification: window?.parleySettings?.roomNumber || ApiOptions.accountIdentification,
@@ -587,6 +590,10 @@ export default class App extends React.Component {
 					objectToSaveIntoState = {interfaceTexts: {welcomeMessage: value}};
 				} else if(path[layer2] === "placeholderMessenger") {
 					objectToSaveIntoState = {interfaceTexts: {inputPlaceholder: value}};
+				} else if(path[layer2] === "messageSendFailed") {
+					objectToSaveIntoState = {interfaceTexts: {sendingMessageFailedError: value}};
+				} else if(path[layer2] === "serviceUnreachableNotification") {
+					objectToSaveIntoState = {interfaceTexts: {serviceUnreachableError: value}};
 				}
 			} else if(path[layer1] === "country") {
 				objectToSaveIntoState = {interfaceLanguage: value};


### PR DESCRIPTION
There is an issue when trying to override any of [these](https://github.com/parley-messaging/web-library/blob/1541468ec0ccde220983016801ab322b58616366/src/UI/App.jsx#L56-L65) interface texts.

For example when setting `window.parleySettings.runOptions.interfaceTexts.title = "abc"`, the `title`  would be set to the [default text](https://github.com/parley-messaging/web-library/blob/1541468ec0ccde220983016801ab322b58616366/src/UI/Scripts/Context.js#L32-L32).

This is due to this rule https://github.com/parley-messaging/web-library/blob/1541468ec0ccde220983016801ab322b58616366/src/UI/App.jsx#L56-L57

`desc` is not set here (because we want to use the new name `title`), so it uses the context's default value.

To fix this i have placed the `loadInterfaceTextOverrides()` call underneath the 'deprecated names' part. This way you can always override any interfaceTexts using `window.parleySettings.runOptions.interfaceTexts`.

I have also made the following texts reactive, because they were missing:
- messageSendFailed
- serviceUnreachableNotification

## @ reviewer; Please also review my [documentation changes](https://developers.parley.nu/suggested-edits/6669b96e1eba980058aafd33)