### PR TITLE
Make `window.parleySettings.interface` reactive

### DIFF
--- a/cypress/e2e/ui_spec.js
+++ b/cypress/e2e/ui_spec.js
@@ -3893,6 +3893,36 @@ describe("UI", () => {
 						.find("[class^=parley-messaging-launcher__]")
 						.find("[class^=parley-messaging-unreadMessagesBadge__]")
 						.should("not.exist");
+
+					// Test that it changes during runtime
+					cy.fixture("getMessagesResponse.json")
+						.then((fixture) => {
+							const _fixture = fixture;
+							_fixture.data = [
+								{
+									...fixture.data[0],
+									id: 9999,
+									time: Date.now(),
+								},
+							];
+							cy.intercept("GET", messagesUrlRegex, _fixture)
+								.as("getMessages2");
+						});
+					cy.window()
+						.then((win) => {
+							// eslint-disable-next-line no-param-reassign
+							win.parleySettings.interface.unreadMessagesAction = 1;
+						});
+					clickOnLauncher();
+					cy.wait("@getMessages2");
+					cy.get("@app")
+						.find("[class^=parley-messaging-launcher__]")
+						.find("[class^=parley-messaging-unreadMessagesBadge__]")
+						.should("have.text", 1)
+						.should("be.visible");
+					cy.get("@app")
+						.find("[class^=parley-messaging-chat__]")
+						.should("not.be.visible");
 				});
 				it("should show an unread messages counter when new agent messages are received while the chat is closed (using value 1) and device has ben registered before and previous state is minimized", () => {
 					// Make sure to set the correct unread message action

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "parley-web-library",
-	"version": "2.0.0-alpha.14",
+	"version": "2.0.0-alpha.17",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "parley-web-library",
-			"version": "2.0.0-alpha.14",
+			"version": "2.0.0-alpha.17",
 			"license": "MIT",
 			"dependencies": {
 				"@fortawesome/fontawesome-free": "^6.5.2",

--- a/src/UI/App.jsx
+++ b/src/UI/App.jsx
@@ -123,6 +123,8 @@ export default class App extends React.Component {
 			= window.parleySettings.runOptions.interfaceTexts ? window.parleySettings.runOptions.interfaceTexts : {};
 		window.parleySettings.devicePersistence
 			= window.parleySettings.devicePersistence ? window.parleySettings.devicePersistence : {};
+		window.parleySettings.interface
+			= window.parleySettings.interface ? window.parleySettings.interface : {};
 
 		// Store library version into window
 		window.parleySettings.version = version;


### PR DESCRIPTION
This fixes a small problem where changes to `window.parleySettings.interface` were not recognized during runtime. 

This was found during testing of release `v2.0.0-alpha.17` where we added the new unread messages badge.

The fix has been added to that release but not yet to master.