### PR TITLE
Fix bug where chat window opens when it shouldn't

### DIFF
--- a/cypress/e2e/ui_spec.js
+++ b/cypress/e2e/ui_spec.js
@@ -4297,6 +4297,60 @@ describe("UI", () => {
 					.should("not.exist");
 			});
 		});
+		describe("using value 'minimize' in storage", () => {
+			beforeEach(() => {
+				cy.window()
+					.then((win) => {
+						win.localStorage.setItem("messengerOpenState", "minimize");
+					});
+			});
+			it(`should not show the chat if the value is 'minimize' but you have not registered your device yet`, () => {
+				cy.intercept("POST", "*/**/devices", cy.spy().as("postDevicesSpy"));
+
+				visitHome({interface: {unreadMessagesAction: 0}});
+
+				cy.get("@app")
+					.find("[class^=parley-messaging-launcher__]")
+					.find("button")
+					.should("be.visible");
+
+				// We need to wait for the chat to complete it's `componentDidMount()`
+				// to see if it decides to start the polling service or not.
+				// I don't see a better way of checking this...
+				// eslint-disable-next-line cypress/no-unnecessary-waiting
+				cy.wait(2000);
+
+				// POST devices should not have been called on app startup
+				cy.get("@postDevicesSpy").should("not.have.been.called");
+
+				// Chat window should not be visible since there is no device registration
+				cy.get("@app")
+					.find("[class^=parley-messaging-chat__]")
+					.should("not.be.visible");
+
+				// Refresh page
+				cy.reload();
+
+				cy.get("@app")
+					.find("[class^=parley-messaging-launcher__]")
+					.find("button")
+					.should("be.visible");
+
+				// We need to wait for the chat to complete it's `componentDidMount()`
+				// to see if it decides to start the polling service or not.
+				// I don't see a better way of checking this...
+				// eslint-disable-next-line cypress/no-unnecessary-waiting
+				cy.wait(2000);
+
+				// POST devices should still not have been called on app startup
+				cy.get("@postDevicesSpy").should("not.have.been.called");
+
+				// Chat window should not be visible since there is still no device registration
+				cy.get("@app")
+					.find("[class^=parley-messaging-chat__]")
+					.should("not.be.visible");
+			});
+		});
 	});
 	describe("images", () => {
 		it("should open the fullscreen view on click and close it with the close button", () => {

--- a/cypress/e2e/ui_spec.js
+++ b/cypress/e2e/ui_spec.js
@@ -1593,7 +1593,7 @@ describe("UI", () => {
 					// These things are necessary for slow polling to start
 					// and in turn for opening the chat window on new messages
 					win.localStorage.setItem("messengerOpenState", "minimize");
-					win.localStorage.setItem("deviceInformation", JSON.stringify({deviceIdentification: "d5629d6f-ac09-4ee5-8631-abf4d9f4885b"}));
+					win.localStorage.setItem("deviceInformation", JSON.stringify({deviceIdentification: "aaaaaaaa-ac09-4ee5-8631-abf4d9f4885b"}));
 				});
 			visitHome();
 
@@ -3934,7 +3934,7 @@ describe("UI", () => {
 
 							// These things are necessary for slow polling to start
 							win.localStorage.setItem("messengerOpenState", "minimize");
-							win.localStorage.setItem("deviceInformation", JSON.stringify({deviceIdentification: "d5629d6f-ac09-4ee5-8631-abf4d9f4885b"}));
+							win.localStorage.setItem("deviceInformation", JSON.stringify({deviceIdentification: "aaaaaaaa-ac09-4ee5-8631-abf4d9f4885b"}));
 						});
 
 					// Intercept the get messages

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "parley-web-library",
-	"version": "2.0.0-alpha.18",
+	"version": "2.0.0-alpha.19",
 	"description": "Front-end solution for Parley",
 	"private": true,
 	"targets": {

--- a/src/UI/App.jsx
+++ b/src/UI/App.jsx
@@ -486,7 +486,7 @@ export default class App extends React.Component {
 		// Start slow polling if there was a chat started sometime before and chat starts minimized
 		if(messengerOpenState === MessengerOpenState.minimize) {
 			const devicePreviouslyRegistered = localStorage.getItem("deviceInformation") !== null;
-			if(devicePreviouslyRegistered !== null) {
+			if(devicePreviouslyRegistered) {
 				Logger.debug("Starting slow polling service because device is previously registered");
 				if(this.PollingService.isRunning) {
 					Logger.debug("Main polling service is running, stopping it because we only want slow polling at this moment");

--- a/src/UI/index.jsx
+++ b/src/UI/index.jsx
@@ -15,9 +15,9 @@ Logger.useDefaults({
 
 const mountNode = document.getElementById("app");
 
-window.initParleyMessenger = () => {
+window.initParleyMessenger = (debug = false) => {
 	// eslint-disable-next-line no-undef
-	if(process.env.NODE_ENV === "development") {
+	if(process.env.NODE_ENV === "development" || debug === true) {
 		Logger.setLevel(Logger.DEBUG); // Make sure you enable "verbose" logging in your console to see DEBUG logs
 		ReactDOM.render(<App debug={true} />, mountNode);
 	} else {


### PR DESCRIPTION
This fixes a bug where the chat window opened after reloading the page. 

When checking the localStorage for previous subscribed device information we always continued due to a wrong boolean check. This caused the slow polling to always start (and not just when the device was registered before). Which in turn causes a device registration. This is triggered by the `messengerOpenState: minimize` being set, so the first page load doesn't show the chat but the second one does. Because when there is no `messengerOpenState` in the storage we save `minimize` as the default. 

I also added a param to `window.initParleyMessenger()` to enable debug logs on clients outside of this development environment. This way we can request debug logs when a bug appears.