### PR TITLE
Use new client-api endpoint for counting unread messages 

### DIFF
--- a/cypress/e2e/api-class_spec.js
+++ b/cypress/e2e/api-class_spec.js
@@ -36,10 +36,6 @@ const primitiveTypes = [
 		value: 123,
 	},
 	{
-		type: "bigint",
-		value: 2n,
-	},
-	{
 		type: "boolean",
 		value: false,
 	},

--- a/cypress/e2e/polling_spec.js
+++ b/cypress/e2e/polling_spec.js
@@ -169,7 +169,7 @@ describe("Polling Service", () => {
 						}
 
 						calls = 0;
-						pollingService.restartMainPolling();
+						pollingService.restartPolling();
 					}
 				},
 			};

--- a/cypress/e2e/polling_spec.js
+++ b/cypress/e2e/polling_spec.js
@@ -169,7 +169,7 @@ describe("Polling Service", () => {
 						}
 
 						calls = 0;
-						pollingService.restartPolling();
+						pollingService.restartMainPolling();
 					}
 				},
 			};

--- a/cypress/e2e/ui_spec.js
+++ b/cypress/e2e/ui_spec.js
@@ -1567,6 +1567,10 @@ describe("UI", () => {
 			cy.fixture("getMessagesResponse.json")
 				.as("fixture");
 
+			// Intercept the count which is responsible for popping open the chat window
+			cy.intercept("GET", "*/**/messages/unseen/count", {fixture: "getMessagesUnreadCountResponse.json"})
+				.as("getUnseenMessagesCount");
+
 			cy.get("@fixture")
 				.then((fixture) => {
 					for(let i = 1; i < 10; i++) {
@@ -1597,6 +1601,7 @@ describe("UI", () => {
 				});
 			visitHome();
 
+			cy.wait("@getUnseenMessagesCount");
 			cy.wait("@getMessages");
 
 			// Validate that we have scrolled to the latest message

--- a/cypress/e2e/ui_spec.js
+++ b/cypress/e2e/ui_spec.js
@@ -1953,7 +1953,8 @@ describe("UI", () => {
 									...json,
 									welcomeMessage: null,
 								};
-								cy.intercept("GET", messagesUrlRegex, _json);
+								cy.intercept("GET", messagesUrlRegex, _json)
+									.as("getMessages");
 							});
 
 						visitHome(parleyConfig);
@@ -1975,6 +1976,8 @@ describe("UI", () => {
 								// eslint-disable-next-line no-param-reassign
 								win.parleySettings.runOptions.interfaceTexts.infoText = newInfoText;
 							});
+
+						cy.wait("@getMessages");
 
 						cy.get("@app")
 							.find("[class*=parley-messaging-announcement__]")

--- a/cypress/fixtures/getMessageWithAllPartsResponse.json
+++ b/cypress/fixtures/getMessageWithAllPartsResponse.json
@@ -41,7 +41,8 @@
 					"payload": "Ik heb een vraag over meubels",
 					"type": "reply"
 				}
-			]
+			],
+			"status": 2
 		}
 	],
 	"paging": {

--- a/cypress/fixtures/getMessageWithButtonsResponse.json
+++ b/cypress/fixtures/getMessageWithButtonsResponse.json
@@ -28,7 +28,8 @@
 					"payload": "Ik heb een vraag over meubels",
 					"type": "reply"
 				}
-			]
+			],
+			"status": 2
 		},
 		{
 			"id": 10697,
@@ -58,7 +59,8 @@
 					"payload": "Ik heb een vraag over meubels",
 					"type": "reply"
 				}
-			]
+			],
+			"status": 2
 		}
 	],
 	"paging": {

--- a/cypress/fixtures/getMessageWithCarouselButtonItems.json
+++ b/cypress/fixtures/getMessageWithCarouselButtonItems.json
@@ -46,7 +46,8 @@
 			"custom": [],
 			"title": null,
 			"media": null,
-			"buttons": []
+			"buttons": [],
+			"status": 2
 		},
 		{
 			"id": 10738,
@@ -65,7 +66,8 @@
 			"custom": [],
 			"title": null,
 			"media": null,
-			"buttons": []
+			"buttons": [],
+			"status": 2
 		}
 	],
 	"paging": {

--- a/cypress/fixtures/getMessageWithCarouselImageItems.json
+++ b/cypress/fixtures/getMessageWithCarouselImageItems.json
@@ -38,7 +38,8 @@
 			"custom": [],
 			"title": null,
 			"media": null,
-			"buttons": []
+			"buttons": [],
+			"status": 2
 		},
 		{
 			"id": 10738,
@@ -57,7 +58,8 @@
 			"custom": [],
 			"title": null,
 			"media": null,
-			"buttons": []
+			"buttons": [],
+			"status": 2
 		}
 	],
 	"paging": {

--- a/cypress/fixtures/getMessageWithCarouselTextItems.json
+++ b/cypress/fixtures/getMessageWithCarouselTextItems.json
@@ -30,7 +30,8 @@
 			"custom": [],
 			"title": null,
 			"media": null,
-			"buttons": []
+			"buttons": [],
+			"status": 2
 		},
 		{
 			"id": 10738,
@@ -49,7 +50,8 @@
 			"custom": [],
 			"title": null,
 			"media": null,
-			"buttons": []
+			"buttons": [],
+			"status": 2
 		}
 	],
 	"paging": {

--- a/cypress/fixtures/getMessageWithImageResponse.json
+++ b/cypress/fixtures/getMessageWithImageResponse.json
@@ -25,7 +25,8 @@
 				"filename": "41cedb695613d417be10c65f089521599c103cc9.png",
 				"description": "2117234911_1686055386_2743.png"
 			},
-			"buttons": []
+			"buttons": [],
+			"status": 2
 		},
 		{
 			"id": 5681,
@@ -52,7 +53,8 @@
 				"filename": "41cedb695613d417be10c65f089521599c103cc9.png",
 				"description": "2117234911_1686055386_2743.png"
 			},
-			"buttons": []
+			"buttons": [],
+			"status": 2
 		}
 	],
 	"paging": {

--- a/cypress/fixtures/getMessageWithPdfResponse.json
+++ b/cypress/fixtures/getMessageWithPdfResponse.json
@@ -25,7 +25,8 @@
 				"filename": "41cedb695613d417be10c65f089521599c103cc9.pdf",
 				"description": "2117234911_1686055386_2743.pdf"
 			},
-			"buttons": []
+			"buttons": [],
+			"status": 2
 		}
 	],
 	"paging": {

--- a/cypress/fixtures/getMessageWithTitleResponse.json
+++ b/cypress/fixtures/getMessageWithTitleResponse.json
@@ -17,7 +17,8 @@
 			"custom": [],
 			"title": "This is a title",
 			"media": null,
-			"buttons": []
+			"buttons": [],
+			"status": 2
 		}
 	],
 	"paging": {

--- a/cypress/fixtures/getMessagesResponse.json
+++ b/cypress/fixtures/getMessagesResponse.json
@@ -17,7 +17,8 @@
 			"custom": [],
 			"title": null,
 			"media": null,
-			"buttons": []
+			"buttons": [],
+			"status": 2
 		},
 		{
 			"id": 10736,
@@ -31,7 +32,8 @@
 			"custom": [],
 			"title": null,
 			"media": null,
-			"buttons": []
+			"buttons": [],
+			"status":  2
 		}
 	],
 	"paging": {

--- a/cypress/fixtures/getMessagesUnreadCountResponse.json
+++ b/cypress/fixtures/getMessagesUnreadCountResponse.json
@@ -1,0 +1,18 @@
+{
+	"data": {
+		"messageIds": [
+			1,
+			2
+		],
+		"count": 2
+	},
+	"notifications": [],
+	"status": "SUCCESS",
+	"metadata": {
+		"values": {
+			"url": "messages/unseen/count"
+		},
+		"method": "get",
+		"duration": 0.01
+	}
+}

--- a/cypress/fixtures/getMessagesWithMultipleAgents.json
+++ b/cypress/fixtures/getMessagesWithMultipleAgents.json
@@ -17,7 +17,8 @@
 			"custom": [],
 			"title": null,
 			"media": null,
-			"buttons": []
+			"buttons": [],
+			"status": 2
 		},
 		{
 			"id": 10737,
@@ -36,7 +37,8 @@
 			"custom": [],
 			"title": null,
 			"media": null,
-			"buttons": []
+			"buttons": [],
+			"status":  2
 		},
 		{
 			"id": 10736,
@@ -50,7 +52,8 @@
 			"custom": [],
 			"title": null,
 			"media": null,
-			"buttons": []
+			"buttons": [],
+			"status": 2
 		}
 	],
 	"paging": {

--- a/cypress/fixtures/getMessagesWithOneAgent.json
+++ b/cypress/fixtures/getMessagesWithOneAgent.json
@@ -17,7 +17,8 @@
 			"custom": [],
 			"title": null,
 			"media": null,
-			"buttons": []
+			"buttons": [],
+			"status": 2
 		},
 		{
 			"id": 10737,
@@ -36,7 +37,8 @@
 			"custom": [],
 			"title": null,
 			"media": null,
-			"buttons": []
+			"buttons": [],
+			"status": 2
 		},
 		{
 			"id": 10736,
@@ -50,7 +52,8 @@
 			"custom": [],
 			"title": null,
 			"media": null,
-			"buttons": []
+			"buttons": [],
+			"status": 2
 		}
 	],
 	"paging": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "parley-web-library",
-	"version": "2.0.0-alpha.18",
+	"version": "2.0.0-alpha.19",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "parley-web-library",
-			"version": "2.0.0-alpha.18",
+			"version": "2.0.0-alpha.19",
 			"license": "MIT",
 			"dependencies": {
 				"@fortawesome/fontawesome-free": "^6.5.2",
@@ -6037,9 +6037,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001632",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001632.tgz",
-			"integrity": "sha512-udx3o7yHJfUxMLkGohMlVHCvFvWmirKh9JAH/d7WOLPetlH+LTL5cocMZ0t7oZx/mdlOWXti97xLZWc8uURRHg==",
+			"version": "1.0.30001715",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001715.tgz",
+			"integrity": "sha512-7ptkFGMm2OAOgvZpwgA4yjQ5SQbrNVGdRjzH0pBdy1Fasvcr+KAeECmbCAECzTuDuoX0FCY8KzUxjf9+9kfZEw==",
 			"dev": true,
 			"funding": [
 				{
@@ -22540,9 +22540,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001632",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001632.tgz",
-			"integrity": "sha512-udx3o7yHJfUxMLkGohMlVHCvFvWmirKh9JAH/d7WOLPetlH+LTL5cocMZ0t7oZx/mdlOWXti97xLZWc8uURRHg==",
+			"version": "1.0.30001715",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001715.tgz",
+			"integrity": "sha512-7ptkFGMm2OAOgvZpwgA4yjQ5SQbrNVGdRjzH0pBdy1Fasvcr+KAeECmbCAECzTuDuoX0FCY8KzUxjf9+9kfZEw==",
 			"dev": true
 		},
 		"caseless": {

--- a/src/Api/Api.js
+++ b/src/Api/Api.js
@@ -12,7 +12,15 @@ import {
 	DeviceVersionMinLength, DeviceVersionRegex, MinUdidLength,
 } from "./Constants/Other";
 import ApiResponseEvent from "./Private/ApiResponseEvent";
-import {media, mediaUploaded, messages, messageSent, subscribe} from "./Constants/Events";
+import {
+	media,
+	mediaUploaded,
+	messages,
+	messageSent,
+	messageStatusUpdated,
+	subscribe,
+	unreadMessagesCount,
+} from "./Constants/Events";
 import PushTypes from "./Constants/PushTypes";
 import DeviceTypes from "./Constants/DeviceTypes";
 import {
@@ -22,6 +30,7 @@ import {
 import {error as ErrorStatus} from "./Constants/ApiResponseStatuses";
 import {CUSTOMHEADER_BLACKLIST} from "./Constants/CustomHeaderBlacklist";
 import {isSupportedMediaType} from "./Constants/SupportedMediaTypes";
+import {STATUS_AVAILABLE, STATUS_RECEIVED, STATUS_SEEN} from "./Constants/Statuses";
 
 export default class Api {
 	constructor(
@@ -233,6 +242,7 @@ export default class Api {
 		if(id !== undefined)
 			url = `${this.config.apiUrl}/messages/${filter}:${id}`;
 
+
 		return this.fetchWrapper(url, {method: "GET"})
 			.then((data) => {
 				this.eventTarget.dispatchEvent(new ApiResponseEvent(messages, data));
@@ -319,6 +329,46 @@ export default class Api {
 			})
 			.catch((errorNotifications, warningNotifications) => {
 				this.eventTarget.dispatchEvent(new ApiResponseEvent(messageSent, {
+					errorNotifications,
+					warningNotifications,
+					data: null,
+				}));
+			});
+	}
+
+	// TODO: @gerben; make tests
+	getUnreadMessagesCount() {
+		return this.fetchWrapper(`${this.config.apiUrl}/messages/unseen/count`, {method: "GET"})
+			.then((data) => {
+				this.eventTarget.dispatchEvent(new ApiResponseEvent(unreadMessagesCount, data));
+				return data;
+			})
+			.catch((errorNotifications, warningNotifications) => {
+				this.eventTarget.dispatchEvent(new ApiResponseEvent(unreadMessagesCount, {
+					errorNotifications,
+					warningNotifications,
+					data: null,
+				}));
+			});
+	}
+
+	// TODO: @gerben; make tests
+	updateMessagesStatus(newStatus, messageIds) {
+		ow(newStatus, "newStatus", ow.number.oneOf([
+			STATUS_AVAILABLE, STATUS_RECEIVED, STATUS_SEEN,
+		]));
+		ow(messageIds, "messageIds", ow.array.nonEmpty);
+
+		return this.fetchWrapper(`${this.config.apiUrl}/messages/status/${newStatus}`, {
+			method: "PUT",
+			body: JSON.stringify({messageIds}),
+		})
+			.then((data) => {
+				this.eventTarget.dispatchEvent(new ApiResponseEvent(messageStatusUpdated, data));
+				return data;
+			})
+			.catch((errorNotifications, warningNotifications) => {
+				this.eventTarget.dispatchEvent(new ApiResponseEvent(messageStatusUpdated, {
 					errorNotifications,
 					warningNotifications,
 					data: null,

--- a/src/Api/Api.js
+++ b/src/Api/Api.js
@@ -336,7 +336,6 @@ export default class Api {
 			});
 	}
 
-	// TODO: @gerben; make tests
 	getUnreadMessagesCount() {
 		return this.fetchWrapper(`${this.config.apiUrl}/messages/unseen/count`, {method: "GET"})
 			.then((data) => {
@@ -352,7 +351,6 @@ export default class Api {
 			});
 	}
 
-	// TODO: @gerben; make tests
 	updateMessagesStatus(newStatus, messageIds) {
 		ow(newStatus, "newStatus", ow.number.oneOf([
 			STATUS_AVAILABLE, STATUS_RECEIVED, STATUS_SEEN,

--- a/src/Api/Constants/Events.js
+++ b/src/Api/Constants/Events.js
@@ -5,3 +5,5 @@ export const messageSent = "messagesent";
 export const messages = "messages";
 export const media = "media";
 export const mediaUploaded = "mediauploaded";
+export const unreadMessagesCount = "unreadMessagesCount";
+export const messageStatusUpdated = "messageStatusUpdated";

--- a/src/Api/Constants/Statuses.js
+++ b/src/Api/Constants/Statuses.js
@@ -1,0 +1,3 @@
+export const STATUS_AVAILABLE = 2;
+export const STATUS_RECEIVED = 3;
+export const STATUS_SEEN = 4;

--- a/src/Api/Polling.js
+++ b/src/Api/Polling.js
@@ -145,6 +145,10 @@ export default class PollingService {
 		return timeValue * intervalTimeUnits[timeUnit];
 	}
 
+	async pollFunction() {
+		await this.api.getMessages(this.lastMessageIdReceived, "after");
+	}
+
 	async pollInterval() {
 		if(!this.api.deviceRegistered) {
 			this.logger.warn("Polling interval canceled because device is not yet registered!");
@@ -152,7 +156,7 @@ export default class PollingService {
 		}
 
 		// Get messages
-		await this.api.getMessages(this.lastMessageIdReceived, "after");
+		await this.pollFunction();
 
 		// Increase poll counter for this interval
 		this.currentIntervalAmount++;

--- a/src/Api/Polling.js
+++ b/src/Api/Polling.js
@@ -19,7 +19,7 @@ const intervalTimeUnits = {
 };
 
 export default class PollingService {
-	constructor(name, api, customIntervals) {
+	constructor(name, api, customIntervals = undefined) {
 		ow(name, "name", ow.string);
 		ow(api, "api", ow.object.partialShape({getMessages: ow.function}));
 		ow(customIntervals, "customIntervals", ow.optional.array.nonEmpty);

--- a/src/Api/Private/Config.js
+++ b/src/Api/Private/Config.js
@@ -4,6 +4,6 @@
 export default class Config {
 	constructor(apiDomain = "https://api.parley.nu") {
 		this.apiDomain = apiDomain;
-		this.apiUrl = `${apiDomain}/clientApi/v1.8`;
+		this.apiUrl = `${apiDomain}/clientApi/v1.9`;
 	}
 }

--- a/src/Api/UnreadMessagesCountPolling.js
+++ b/src/Api/UnreadMessagesCountPolling.js
@@ -1,0 +1,8 @@
+import PollingService from "./Polling";
+
+export default class UnreadMessagesCountPollingService extends PollingService {
+	// TODO: @gerben; make tests
+	async pollFunction() {
+		await this.api.getUnreadMessagesCount();
+	}
+}

--- a/src/Api/UnreadMessagesCountPolling.js
+++ b/src/Api/UnreadMessagesCountPolling.js
@@ -1,7 +1,6 @@
 import PollingService from "./Polling";
 
 export default class UnreadMessagesCountPollingService extends PollingService {
-	// TODO: @gerben; make tests
 	async pollFunction() {
 		await this.api.getUnreadMessagesCount();
 	}

--- a/src/UI/App.jsx
+++ b/src/UI/App.jsx
@@ -96,7 +96,7 @@ export default class App extends React.Component {
 			allowedMediaTypes: window?.parleySettings?.runOptions?.allowedMediaTypes || undefined,
 			amountOfNewAgentMessagesFound: 0,
 			unreadMessagesAction: window?.parleySettings?.interface?.unreadMessagesAction
-				|| this.unreadMessagesActions.showMessageCounterBadge, // this.unreadMessagesActions.openChatWindow,
+				|| this.unreadMessagesActions.openChatWindow,
 		};
 
 		this.Api = new Api(

--- a/src/UI/App.jsx
+++ b/src/UI/App.jsx
@@ -764,7 +764,7 @@ export default class App extends React.Component {
 			amountOfNewAgentMessagesFound: 0,
 		}));
 
-		this.markMessagesAsRead(this.state.newAgentMessages);
+		this.markMessagesAsRead(this.state.newAgentMessages); // TODO: @gerben; dont do this, only mark them as read when rendering them (could probably also remove state.newAgentMessages since it was only used for this)
 
 		// Try to re-register the device if it is not yet registered
 		Logger.debug("Show chat, registering device");
@@ -843,7 +843,7 @@ export default class App extends React.Component {
 		if(this.state.showChat) {
 			// Chat is already shown, so mark messages as read
 			Logger.debug("Marking messages as read, because we have found new messages and the chat is already open");
-			this.markMessagesAsRead(messageIds);
+			this.markMessagesAsRead(messageIds); // TODO: @gerben; dont do this, only mark them as read when rendering them (could probably also remove state.newAgentMessages since it was only used for this)
 		} else if(this.state.unreadMessagesAction === this.unreadMessagesActions.openChatWindow) {
 			// Show the chat when we received a new message
 			Logger.debug("Calling showChat, because we have found new messages and unreadMessagesAction is set to openChatWindow");

--- a/src/UI/App.jsx
+++ b/src/UI/App.jsx
@@ -108,6 +108,7 @@ export default class App extends React.Component {
 		);
 
 		this.initializePollingServices();
+		this.switchActivePollingService(this.UnreadMessagePollingServiceSlow);
 
 		// Make sure layers to proxy exist
 		window.parleySettings
@@ -137,7 +138,7 @@ export default class App extends React.Component {
 		Logger.debug("App initialized");
 	}
 
-	initializePollingServices = (activePollingService) => {
+	initializePollingServices = () => {
 		this.MessagePollingService = new PollingService("message-polling-service", this.Api);
 		this.UnreadMessagePollingServiceSlow = new UnreadMessagesCountPollingService(
 			"unread-messages-polling-service-slow",
@@ -150,8 +151,6 @@ export default class App extends React.Component {
 			"unread-messages-polling-service",
 			this.Api,
 		);
-
-		this.switchActivePollingService(activePollingService ?? this.UnreadMessagePollingServiceSlow);
 	}
 
 	/**
@@ -392,7 +391,8 @@ export default class App extends React.Component {
 				nextState.deviceIdentification,
 				ApiEventTarget,
 			);
-			this.initializePollingServices(this.activePollingService);
+			this.initializePollingServices(); // Update the polling services with the new Api instance
+			this.switchActivePollingService(this.MessagePollingService); // Restart the new message polling service
 			this.subscribeDevice(
 				nextState.userAdditionalInformation,
 				nextState.deviceAuthorization,

--- a/src/UI/App.jsx
+++ b/src/UI/App.jsx
@@ -348,7 +348,7 @@ export default class App extends React.Component {
 				});
 
 				Logger.debug("Restarting polling because device has been registered");
-				this.restartPolling();
+				this.PollingService.startPolling();
 			});
 	};
 
@@ -803,7 +803,9 @@ export default class App extends React.Component {
 			return;
 		}
 
-		this.PollingService.restartPolling();
+
+		if(this.PollingService.isRunning)
+			this.PollingService.restartPolling();
 	};
 
 	handleNewMessage = (eventData) => {

--- a/src/UI/Conversation.jsx
+++ b/src/UI/Conversation.jsx
@@ -99,6 +99,8 @@ class Conversation extends Component {
 			this.markMessagesAsSeen(this.state.messages
 				.filter(message => message.status < STATUS_SEEN)
 				.map(message => message.id));
+
+			this.hasNewUnreadMessages = false;
 		}
 	}
 

--- a/src/UI/Conversation.jsx
+++ b/src/UI/Conversation.jsx
@@ -11,6 +11,7 @@ import Logger from "js-logger";
 import Api from "../Api/Api";
 import Message from "./Message";
 import Carousel from "./Carousel";
+import {STATUS_SEEN} from "../Api/Constants/Statuses";
 
 class Conversation extends Component {
 	constructor(props) {
@@ -23,6 +24,7 @@ class Conversation extends Component {
 		this.scrollDownOnShow = false;
 		this.isFetchingOlderMessages = false;
 		this.hasOlderMessages = true;
+		this.hasNewUnreadMessages = false;
 
 		// state
 		this.state = {
@@ -71,6 +73,33 @@ class Conversation extends Component {
 				this.scrollToBottom();
 			}
 		}
+
+		// Check for changes in messages status
+		if(
+			this.state.messages.filter(message => message.status < STATUS_SEEN).length
+			> prevState.messages.filter(message => message.status < STATUS_SEEN).length
+		) {
+			// We cannot mark the messages as seen yet here, because this can trigger if
+			// the chat is not yet visible. So we should keep track of if we have found
+			// new unread messages and later, once the chat is shown, we can mark them as seen.
+			this.hasNewUnreadMessages = true;
+		}
+
+		// Check for changes in visibility
+		if(this.props.isChatShown && this.hasNewUnreadMessages) {
+			Logger.debug("Updating messages status because there are unseen messages that now have been rendered");
+
+			// If the current state has more seen messages
+			// compared to the previous state,
+			// we should mark them locally as seen.
+			// We can assume they have been rendered because of the isChatShown property.
+			// Apparently this component renders even when not shown, so it is important
+			// we only do this if isChatShown is true, otherwise the message would be marked
+			// as seen while the client can't "see" them yet because the chat is not shown.
+			this.markMessagesAsSeen(this.state.messages
+				.filter(message => message.status < STATUS_SEEN)
+				.map(message => message.id));
+		}
 	}
 
 	scrollToBottom = () => {
@@ -82,7 +111,7 @@ class Conversation extends Component {
 			Logger.debug("Scroll to bottom requested, but the Conversation is hidden. Executing this request when Conversation is visible");
 			this.scrollDownOnShow = true;
 		}
-	}
+	};
 
 	handleMessages = (eventData) => {
 		const newState = {};
@@ -203,7 +232,7 @@ class Conversation extends Component {
 
 		this.handleScrollCloseToBottom(scrollCurrent, scrollTopMax);
 		this.handleScrollCloseToTop(scrollCurrent);
-	}
+	};
 
 	handleScrollCloseToBottom = (scrollCurrent, scrollTopMax) => {
 		const scrollTopMargin = 100; // Roughly the size of 1,5 message bubble + margin
@@ -215,7 +244,7 @@ class Conversation extends Component {
 		} else {
 			this.clientHasScrolledManually = true;
 		}
-	}
+	};
 
 	handleScrollCloseToTop = (scrollCurrent) => {
 		const scrollTopMargin = 500; // Roughly the size of 5 * 1,5 message bubble + margin
@@ -235,7 +264,28 @@ class Conversation extends Component {
 					this.isFetchingOlderMessages = false;
 				});
 		}
-	}
+	};
+
+	markMessagesAsSeen = (messageIds) => {
+		if(messageIds.length === 0)
+			return;
+
+		Logger.debug(`Marking the following messages as seen, because they have been rendered: ${messageIds.join(",")}`);
+
+		// Mark them seen locally first, so subsequent renders would not cause this method to update them again
+		this.setState((prevState) => {
+			const stateMessages = prevState.messages;
+			messageIds.forEach((id) => {
+				const stateMessageIndex = stateMessages.findIndex(x => x.id === id);
+				if(stateMessageIndex > -1)
+					stateMessages[stateMessageIndex].status = STATUS_SEEN;
+			});
+			return {messages: stateMessages};
+		});
+
+		// Mark them externally as seen
+		this.props.api.updateMessagesStatus(STATUS_SEEN, messageIds);
+	};
 
 	render() {
 		this.renderedDates = []; // Reset the rendered dates


### PR DESCRIPTION
This PR uses the new `GET /messages/unread/count` client api endpoint to check for unread messages. This replaces the `GET /messages` polling while the chat is closed. If the chat is open it will use that polling for retrieving the full message objects.

The polling now works as follows:
- if the chat is closed and has never been opened in this session it uses the slow unread message count polling. This is the same as it was before this PR
- if the chat is open it uses the message polling, just like before
- if the chat is closed after it has been open it will use the unread message count polling but with the same intervals as the message polling, so not "slow".

If we get a count which is greater than 0 the chat will open up (depending on your `unreadMessagesAction` in the config).

Once the unread messages have been rendered we mark them as "read" in the client api (they are not updated individually, we update all the unread messages that we have in our state once the chat is shown).