### PR TITLE
Render welcome-message more intelligent

### DIFF
--- a/cypress/e2e/ui_spec.js
+++ b/cypress/e2e/ui_spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable @babel/no-invalid-this */
 import {InterfaceTexts} from "../../src/UI/Scripts/Context";
 import {version} from "../../package.json";
 import {generateParleyMessages, interceptIndefinitely} from "../support/utils";
@@ -4162,6 +4163,194 @@ describe("UI", () => {
 					.find("[class^=parley-messaging-launcher__]")
 					.find("button")
 					.should("have.id", "launcher");
+			});
+		});
+		describe("Announcement", () => {
+			describe("Welcome message", () => {
+				it("should be shown underneath the latest date if available", () => {
+					// Create a conversation that was started yesterday
+					const yesterday = new Date(Date.now() - 86400000).getTime();
+					const initialMessages = [
+						...generateParleyMessages(4, yesterday),
+						...generateParleyMessages(1),
+					];
+					cy.fixture("getMessagesResponse.json")
+						.then((fixture) => {
+							// eslint-disable-next-line no-param-reassign
+
+							cy.intercept("GET", messagesUrlRegex, req => req.reply({
+								...fixture,
+								data: initialMessages,
+							}))
+								.as("fetchInitialMessages");
+
+							cy.wrap(fixture.welcomeMessage).as("welcomeMessageText");
+						});
+
+					visitHome();
+					clickOnLauncher();
+					cy.wait("@fetchInitialMessages");
+
+					cy.get("[class*=parley-messaging-announcement__]").first()
+						.as("announcement");
+					cy.get("[class*=parley-messaging-date]").as("date");
+
+					// eslint-disable-next-line func-names
+					cy.then(function () {
+						// Check that the welcome message has the expected text
+						expect(this.announcement).to.have.text(this.welcomeMessageText);
+
+						// Check that the welcome message is underneath the date
+						// eslint-disable-next-line no-bitwise
+						const comparePos = this.date[0].compareDocumentPosition(this.announcement[0])
+							& Node.DOCUMENT_POSITION_FOLLOWING;
+						// eslint-disable-next-line no-unused-expressions
+						expect(comparePos).to.be.ok;
+					});
+				});
+				it("should be shown at the bottom if there are messages but not from today", () => {
+					// Create a conversation that was started yesterday
+					const yesterday = new Date(Date.now() - 86400000).getTime();
+					const initialMessages = generateParleyMessages(4, yesterday);
+					cy.fixture("getMessagesResponse.json")
+						.then((fixture) => {
+							// eslint-disable-next-line no-param-reassign
+
+							cy.intercept("GET", messagesUrlRegex, req => req.reply({
+								...fixture,
+								data: initialMessages,
+								stickyMessage: null,
+							}))
+								.as("fetchMessages");
+
+							cy.wrap(fixture.welcomeMessage).as("welcomeMessageText");
+						});
+
+					visitHome();
+					clickOnLauncher();
+					cy.wait("@fetchMessages");
+
+					cy.get("[class*=parley-messaging-announcement__]")
+						.should("be.visible")
+						.as("announcement");
+
+					// "Send" a new message
+					const testMessage = "Chuck Norris can build a snowman with rain";
+					cy.fixture("getMessagesResponse.json")
+						.then((fixture) => {
+							// eslint-disable-next-line no-param-reassign
+
+							cy.intercept("GET", messagesUrlRegex, req => req.reply({
+								...fixture,
+								data: [
+									...initialMessages,
+									{
+										id: 9999,
+										time: Date.now() / 1000,
+										message: testMessage,
+										image: null,
+										typeId: 1,
+										carousel: [],
+										quickReplies: [],
+										custom: [],
+										title: null,
+										media: null,
+										buttons: [],
+									},
+								],
+								stickyMessage: null,
+							}))
+								.as("fetchMessages");
+						});
+
+					// Trigger new fetch so we don't have to wait for the interval
+					cy.get("@app")
+						.find("[class^=parley-messaging-text__]")
+						.should("be.visible")
+						.find("textarea")
+						.click();
+
+					cy.wait("@fetchMessages");
+					findMessage(testMessage)
+						.as("testMessage");
+
+					// We have to re-get the announcement
+					// Sometimes this reference disappears and we need it in the next check
+					cy.get("[class*=parley-messaging-announcement__]")
+						.should("be.visible")
+						.as("announcement");
+
+					// Make sure the position of the welcome message is correct
+					// eslint-disable-next-line func-names
+					cy.then(function () {
+						// Check that the welcome message is above the new message
+						// eslint-disable-next-line no-bitwise
+						const comparePos = this.announcement[0].compareDocumentPosition(this.testMessage[0])
+							& Node.DOCUMENT_POSITION_FOLLOWING;
+						// eslint-disable-next-line no-unused-expressions
+						expect(comparePos).to.be.ok;
+					});
+				});
+				it("should be shown above the sticky message if the date is not available", () => {
+					// Create an empty conversation
+					cy.fixture("getMessagesResponse.json")
+						.then((fixture) => {
+							// eslint-disable-next-line no-param-reassign
+
+							cy.intercept("GET", messagesUrlRegex, req => req.reply({
+								...fixture,
+								data: [],
+							}))
+								.as("fetchInitialMessages");
+
+							cy.wrap(fixture.welcomeMessage).as("welcomeMessageText");
+						});
+
+					visitHome();
+					clickOnLauncher();
+					cy.wait("@fetchInitialMessages");
+
+					cy.get("[class*=parley-messaging-announcement__]").first()
+						.as("announcement");
+					cy.get("[class*=parley-messaging-announcement__]").eq(1)
+						.as("stickyMessages");
+
+					// eslint-disable-next-line func-names
+					cy.then(function () {
+						// Check that the welcome message has the expected text
+						expect(this.announcement).to.have.text(this.welcomeMessageText);
+
+						// Check that the welcome message is underneath the date
+						// eslint-disable-next-line no-bitwise
+						const comparePos = this.announcement[0].compareDocumentPosition(this.stickyMessages[0])
+							& Node.DOCUMENT_POSITION_FOLLOWING;
+						// eslint-disable-next-line no-unused-expressions
+						expect(comparePos).to.be.ok;
+					});
+				});
+				it("should be shown even if there is no sticky message and no conversation messages", () => {
+					// Create an empty conversation
+					cy.fixture("getMessagesResponse.json")
+						.then((fixture) => {
+							// eslint-disable-next-line no-param-reassign
+
+							cy.intercept("GET", messagesUrlRegex, req => req.reply({
+								...fixture,
+								data: [],
+								stickyMessage: null,
+							}))
+								.as("fetchInitialMessages");
+
+							cy.wrap(fixture.welcomeMessage).as("welcomeMessageText");
+						});
+
+					visitHome();
+					clickOnLauncher();
+					cy.wait("@fetchInitialMessages");
+
+					cy.get("[class*=parley-messaging-announcement__]").first()
+						.should("be.visible");
+				});
 			});
 		});
 	});

--- a/cypress/e2e/ui_spec.js
+++ b/cypress/e2e/ui_spec.js
@@ -6,7 +6,7 @@ import {SUPPORTED_MEDIA_TYPES} from "../../src/Api/Constants/SupportedMediaTypes
 import {STATUS_AVAILABLE} from "../../src/Api/Constants/Statuses";
 
 const defaultParleyConfig = {roomNumber: "0cce5bfcdbf07978b269"};
-const messagesUrlRegex = /.*\/messages(?:\/after:\d+)?(?!\/)/u; // This matches /messages and /messages/after:123
+const messagesUrlRegex = /.*\/messages(?:\/(?:after|before):\d+)?(?!\/)/u; // This matches /messages and /messages/after:123
 
 function visitHome(parleyConfig, onBeforeLoad, onLoad) {
 	cy.visit("/", {
@@ -4193,7 +4193,8 @@ describe("UI", () => {
 
 					cy.get("[class*=parley-messaging-announcement__]").first()
 						.as("announcement");
-					cy.get("[class*=parley-messaging-date]").as("date");
+					cy.get("[class*=parley-messaging-date]").last()
+						.as("date");
 
 					// eslint-disable-next-line func-names
 					cy.then(function () {

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -25,10 +25,10 @@ export function interceptIndefinitely(method, routeMatcher, response = undefined
 	return {sendResponse};
 }
 
-export function generateParleyMessages(amount) {
+export function generateParleyMessages(amount, dateMs = Date.now()) {
 	const messages = [];
 	const timeBetweenMessages = 30; // seconds
-	const beginTime = Date.now() - (amount * timeBetweenMessages);
+	const beginTime = (dateMs / 1000) - (amount * timeBetweenMessages);
 	const chanceForAgentMessage = 0.4;
 
 	for(let i = 0; i < amount; i++) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "parley-web-library",
-	"version": "2.0.0-alpha.19",
+	"version": "2.0.0-alpha.20",
 	"description": "Front-end solution for Parley",
 	"private": true,
 	"targets": {

--- a/src/UI/App.jsx
+++ b/src/UI/App.jsx
@@ -31,7 +31,7 @@ import UnreadMessagesCountPollingService from "../Api/UnreadMessagesCountPolling
 
 export default class App extends React.Component {
 	constructor(props) {
-		Logger.debug("Initializing app");
+		Logger.debug(`Initializing app, version: ${version}`);
 
 		super(props);
 

--- a/src/UI/Conversation.jsx
+++ b/src/UI/Conversation.jsx
@@ -25,6 +25,7 @@ class Conversation extends Component {
 		this.isFetchingOlderMessages = false;
 		this.hasOlderMessages = true;
 		this.hasNewUnreadMessages = false;
+		this.welcomeMessageAnnouncementRendered = false;
 
 		// state
 		this.state = {
@@ -289,9 +290,29 @@ class Conversation extends Component {
 		this.props.api.updateMessagesStatus(STATUS_SEEN, messageIds);
 	};
 
+	shouldRenderWelcomeMessageUnderDate = (message) => {
+		const msInSecond = 1000;
+		const isMessageTimeToday
+			= this.getDateFromTimestamp(message.time) === this.getDateFromTimestamp(Date.now() / msInSecond);
+		const isDateRendered = this.renderedDates.includes(this.getDateFromTimestamp(message.time));
+
+		return isMessageTimeToday && isDateRendered;
+	}
+
+	renderWelcomeMessageAnnouncement = () => {
+		if(!this.state.welcomeMessage)
+			return null;
+		if(this.welcomeMessageAnnouncementRendered)
+			return null;
+
+		this.welcomeMessageAnnouncementRendered = true;
+		return <Announcement message={this.state.welcomeMessage} />;
+	}
+
 	render() {
 		this.renderedDates = []; // Reset the rendered dates
 		const bodyRole = "feed"; // Used to keep jsx-a11y/no-static-element-interactions happy, not sure if this is the best fitting role...
+		this.welcomeMessageAnnouncementRendered = false;
 
 		return (
 			<div className={styles.wrapper}>
@@ -303,15 +324,15 @@ class Conversation extends Component {
 					tabIndex={-1} // tabIndex is required for onKeyDown to work
 				>
 					{
-						this.state.welcomeMessage
-						&& <Announcement message={this.state.welcomeMessage} />
-					}
-					{
 						this.state.messages.map((message, index, array) => (
 							<React.Fragment key={message.id}>
 								{
 									this.setRenderedDate(this.getDateFromTimestamp(message.time))
 									&& <DateGroup timestamp={message.time} />
+								}
+								{
+									this.shouldRenderWelcomeMessageUnderDate(message)
+									&& this.renderWelcomeMessageAnnouncement()
 								}
 								{
 									message.carousel.length === 0
@@ -352,6 +373,10 @@ class Conversation extends Component {
 								}
 							</React.Fragment>
 						))
+					}
+					{
+						this.welcomeMessageAnnouncementRendered === false
+						&& this.renderWelcomeMessageAnnouncement()
 					}
 					{
 						this.state.stickyMessage

--- a/src/UI/Conversation.jsx
+++ b/src/UI/Conversation.jsx
@@ -374,10 +374,7 @@ class Conversation extends Component {
 							</React.Fragment>
 						))
 					}
-					{
-						this.welcomeMessageAnnouncementRendered === false
-						&& this.renderWelcomeMessageAnnouncement()
-					}
+					{this.renderWelcomeMessageAnnouncement()}
 					{
 						this.state.stickyMessage
 						&& <Announcement message={this.state.stickyMessage} />


### PR DESCRIPTION
This PR positions the welcome-message more intelligent than before. Before it always showed the welcome-message at the top of the conversation, but this can easily be missed if you have an existing conversation.

To combat this we now show the welcome-message:
- below the date header if it is the same day as today
- above the sticky message (or "OOO" message) if there are no messages
- above the sticky message (or "OOO" message) if there are messages, but no date header that equals the current date

We only show it below the date header if the date is equal to the current date, because we think that the welcome-message is only helpfull on the day you open the chat.

Here are some screenshots showing the different scenarios

_Welcome message at the top, because the messages (and thus the date headers) are missing_
![msrdc_9nMnNq6g6e](https://github.com/user-attachments/assets/acc38391-94d9-4687-aea0-acd59a0f17de)

_Welcome message above the sticky message_
![msrdc_r91Isxv49P](https://github.com/user-attachments/assets/429558a3-0540-4fbb-abcd-a2c048b9f367)

_Welcome message below the date header_
![msrdc_nM9MNhL2Gq](https://github.com/user-attachments/assets/c5760d90-971d-4bff-9af2-d06763469a3b)

_Welcome message at the bottom, because there is no date header for the current date_
![msrdc_WWDf1IJM1g](https://github.com/user-attachments/assets/245b9fd9-3c8e-47c6-84ad-062c30ffec77)

_Welcome message below the date header and scrolls with new messages_
![msrdc_deR3PXRz6u](https://github.com/user-attachments/assets/2f5f3fc5-4f9a-4cc9-8a20-f320659fd383)
