### PR TITLE
Fix css module load

### DIFF
--- a/src/UI/Buttons/UploadMedia.jsx
+++ b/src/UI/Buttons/UploadMedia.jsx
@@ -5,7 +5,7 @@ import {InterfaceTextsContext} from "../Scripts/Context";
 import {Button, FileTrigger} from "react-aria-components";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faPaperclip} from "@fortawesome/free-solid-svg-icons";
-import styles from "./UploadMedia.module.css";
+import * as styles from "./UploadMedia.module.css";
 
 class UploadMedia extends Component {
 	static contextType = InterfaceTextsContext;


### PR DESCRIPTION
This resolves the warning when building:

@parcel/packager-css: CSS modules cannot be tree shaken when imported with a default specifier